### PR TITLE
Fix an error of min/max aggregetions withoug GROUP BY clause

### DIFF
--- a/src/test/regress/expected/incremental_matview.out
+++ b/src/test/regress/expected/incremental_matview.out
@@ -244,15 +244,25 @@ SELECT * FROM mv_ivm_avg_bug ORDER BY 1,2,3;
 (5 rows)
 
 ROLLBACK;
--- support MIN(), MAX() aggregation functions 
+-- support MIN(), MAX() aggregation functions
 BEGIN;
 CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_min_max AS SELECT i, MIN(j), MAX(j)  FROM mv_base_a GROUP BY i;
+SELECT * FROM mv_ivm_min_max ORDER BY 1,2,3;
+ i | min | max 
+---+-----+-----
+ 1 |  10 |  10
+ 2 |  20 |  20
+ 3 |  30 |  30
+ 4 |  40 |  40
+ 5 |  50 |  50
+(5 rows)
+
 INSERT INTO mv_base_a VALUES
   (1,11), (1,12),
   (2,21), (2,22),
   (3,31), (3,32),
   (4,41), (4,42),
-  (5,51), (5,52); 
+  (5,51), (5,52);
 SELECT * FROM mv_ivm_min_max ORDER BY 1,2,3;
  i | min | max 
 ---+-----+-----
@@ -275,7 +285,31 @@ SELECT * FROM mv_ivm_min_max ORDER BY 1,2,3;
 (5 rows)
 
 ROLLBACK;
--- restriction of incremental view maintenance
+-- support MIN(), MAX() aggregation functions without GROUP clause
+BEGIN;
+CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_min_max AS SELECT MIN(j), MAX(j)  FROM mv_base_a;
+SELECT * FROM mv_ivm_min_max;
+ min | max 
+-----+-----
+  10 |  50
+(1 row)
+
+INSERT INTO mv_base_a VALUES
+  (0,0), (6,60), (7,70);
+SELECT * FROM mv_ivm_min_max;
+ min | max 
+-----+-----
+   0 |  70
+(1 row)
+
+DELETE FROM mv_base_a WHERE (i,j) IN ((0,0), (7,70));
+SELECT * FROM mv_ivm_min_max;
+ min | max 
+-----+-----
+  10 |  60
+(1 row)
+
+ROLLBACK;
 -- contain system column
 CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm01 AS SELECT i,j,xmin FROM mv_base_a;
 ERROR:  system column is not supported with IVM

--- a/src/test/regress/sql/incremental_matview.sql
+++ b/src/test/regress/sql/incremental_matview.sql
@@ -85,6 +85,7 @@ ROLLBACK;
 -- support MIN(), MAX() aggregation functions
 BEGIN;
 CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_min_max AS SELECT i, MIN(j), MAX(j)  FROM mv_base_a GROUP BY i;
+SELECT * FROM mv_ivm_min_max ORDER BY 1,2,3;
 INSERT INTO mv_base_a VALUES
   (1,11), (1,12),
   (2,21), (2,22),
@@ -96,7 +97,16 @@ DELETE FROM mv_base_a WHERE (i,j) IN ((1,10), (2,21), (3,32));
 SELECT * FROM mv_ivm_min_max ORDER BY 1,2,3;
 ROLLBACK;
 
--- restriction of incremental view maintenance
+-- support MIN(), MAX() aggregation functions without GROUP clause
+BEGIN;
+CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_min_max AS SELECT MIN(j), MAX(j)  FROM mv_base_a;
+SELECT * FROM mv_ivm_min_max;
+INSERT INTO mv_base_a VALUES
+  (0,0), (6,60), (7,70);
+SELECT * FROM mv_ivm_min_max;
+DELETE FROM mv_base_a WHERE (i,j) IN ((0,0), (7,70));
+SELECT * FROM mv_ivm_min_max;
+ROLLBACK;
 
 -- contain system column
 CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm01 AS SELECT i,j,xmin FROM mv_base_a;


### PR DESCRIPTION
This situation was not considered within the previous commit. (#20 )
The regression tests for this view definition are added.

However, additional regression tests uncovered another bug that
plan caches for queries to update min/max values don't work because
only one cache is shared among all matviews. To avoid this stupid
bug, the codes to use this plan caches are commented out. This will
be fixed soon by the following commit.