### PR TITLE
Allow to use aggregate functions for interval type

### DIFF
--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -62,6 +62,7 @@
 #include "nodes/primnodes.h"
 #include "optimizer/optimizer.h"
 #include "commands/defrem.h"
+#include "utils/syscache.h"
 
 
 typedef struct


### PR DESCRIPTION
Aggregate functions for interval type were not considered
and errors occurred when we tried to update matviews due to
add operation with zero value which are not permitted for
interval type. Now addition with zero is not assumed and
aggregate for interval works well. In passing, codes for
updating aggregate values were refactored.

issue #25