### PR TITLE
Add support outer joins in IVM

### DIFF
--- a/src/backend/parser/parse_relation.c
+++ b/src/backend/parser/parse_relation.c
@@ -59,7 +59,6 @@ static void expandTupleDesc(TupleDesc tupdesc, Alias *eref,
 							List **colnames, List **colvars, bool is_ivm);
 static int	specialAttNum(const char *attname);
 static bool isQueryUsingTempRelation_walker(Node *node, void *context);
-static bool isIvmColumn(const char *s);
 
 
 /*
@@ -2575,12 +2574,6 @@ expandRelation(Oid relid, Alias *eref, int rtindex, int sublevels_up,
 					location, include_dropped,
 					colnames, colvars, RelationIsIVM(rel));
 	relation_close(rel, AccessShareLock);
-}
-
-static bool
-isIvmColumn(const char *s)
-{
-	return (strncmp(s, "__ivm_", 6) == 0);
 }
 
 /*

--- a/src/backend/rewrite/rewriteHandler.c
+++ b/src/backend/rewrite/rewriteHandler.c
@@ -1620,13 +1620,12 @@ ApplyRetrieveRule(Query *parsetree,
 			rte = rt_fetch(rt_index, parsetree->rtable);
 			foreach(lc, rte->eref->colnames)
 			{
-				if (!strncmp(strVal(lfirst(lc)), "__ivm_exists", 12))
-					appendStringInfo(&ivm_columns, "%s, ", strVal(lfirst(lc)));
+				if (isIvmColumn((strVal(lfirst(lc)))))
+					appendStringInfo(&ivm_columns, ", %s", strVal(lfirst(lc)));
 			}
-			appendStringInfo(&ivm_columns, "__ivm_count__");
 
 			initStringInfo(&str);
-			appendStringInfo(&str, "SELECT mv.*, %s FROM %s mv, generate_series(1, mv.__ivm_count__)",
+			appendStringInfo(&str, "SELECT mv.* %s FROM %s mv, generate_series(1, mv.__ivm_count__)",
 						ivm_columns.data, quote_qualified_identifier(get_namespace_name(RelationGetNamespace(relation)),
 													RelationGetRelationName(relation)));
 

--- a/src/include/commands/matview.h
+++ b/src/include/commands/matview.h
@@ -34,9 +34,9 @@ extern bool MatViewIncrementalMaintenanceIsEnabled(void);
 
 extern Datum IVM_immediate_before(PG_FUNCTION_ARGS);
 extern Datum IVM_immediate_maintenance(PG_FUNCTION_ARGS);
-extern void AtAbort_IVM(void);
-
 extern Query* rewrite_query_for_exists_subquery(Query *query);
-extern char* getIVMColumnName(RangeTblEntry *rte, char *str);
+extern void AtAbort_IVM(void);
+extern char *getColumnNameStartWith(RangeTblEntry *rte, char *str);
+extern bool isIvmColumn(const char *s);
 
 #endif							/* MATVIEW_H */

--- a/src/test/regress/expected/incremental_matview.out
+++ b/src/test/regress/expected/incremental_matview.out
@@ -3591,7 +3591,238 @@ SELECT is_match();
 ROLLBACK TO p1;
 DROP MATERIALIZED VIEW mv;
 DROP VIEW v;
--- 3-way outer join (inner & FULL)
+-- 3-way outer join (right & inner)
+CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r RIGHT JOIN s ON r.i=s.i INNER JOIN t ON s.j=t.j;
+CREATE VIEW v(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r RIGHT JOIN s ON r.i=s.i INNER JOIN t ON s.j=t.j;
+SAVEPOINT p1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  2 | 2
+   |  4 |  2 | 2
+(2 rows)
+
+INSERT INTO r VALUES (1),(2),(3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+   |  4 |  2 | 2
+(3 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO r VALUES (4),(5);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 4 |  4 |  2 | 2
+(3 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+INSERT INTO s VALUES (1,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |  1 |  3 | 3
+ 1 |  1 |  3 | 3
+ 2 |  2 |  2 | 2
+   |  4 |  2 | 2
+(4 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO s VALUES (2,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |  1 |  3 | 3
+ 1 |  1 |  3 | 3
+ 2 |  2 |  2 | 2
+ 2 |  2 |  3 | 3
+ 2 |  2 |  3 | 3
+   |  4 |  2 | 2
+(6 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+INSERT INTO t VALUES (1),(2);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 | 1
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 | 1
+ 3 |  3 |  1 | 1
+   |  4 |  1 | 1
+   |  4 |  2 | 2
+   |  4 |  2 | 2
+(8 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO t VALUES (3),(4);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 | 1
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 | 1
+ 3 |  3 |  1 | 1
+   |  4 |  1 | 1
+   |  4 |  2 | 2
+   |  4 |  2 | 2
+(8 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM r WHERE i=1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  2 | 2
+   |  4 |  2 | 2
+(2 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM r WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+   |  2 |  2 | 2
+   |  4 |  2 | 2
+(2 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM r WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+   |  2 |  2 | 2
+   |  4 |  2 | 2
+(2 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM s WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+   |  4 |  2 | 2
+(1 row)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM s WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+   |  4 |  2 | 2
+(1 row)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM s WHERE i=4;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+(0 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM t WHERE j=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+(0 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM t WHERE j=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+(0 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DROP MATERIALIZED VIEW mv;
+DROP VIEW v;
+-- 3-way outer join (inner & full)
 CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
  SELECT r.i, s.i, s.j, t.j
    FROM r INNER JOIN s ON r.i=s.i FULL JOIN t ON s.j=t.j;

--- a/src/test/regress/expected/incremental_matview.out
+++ b/src/test/regress/expected/incremental_matview.out
@@ -594,7 +594,7 @@ BEGIN
  RETURN x;
 END;
 $$ LANGUAGE plpgsql;
--- 3-ways outer join (full & full)
+-- 3-way outer join (full & full)
 CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
  SELECT r.i, s.i, s.j, t.j
    FROM r FULL JOIN s ON r.i=s.i FULL JOIN t ON s.j=t.j;
@@ -923,7 +923,7 @@ SELECT is_match();
 ROLLBACK TO p1;
 DROP MATERIALIZED VIEW mv;
 DROP VIEW v;
--- 3-ways outer join (full & left)
+-- 3-way outer join (full & left)
 CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
  SELECT r.i, s.i, s.j, t.j
    FROM r FULL JOIN s ON r.i=s.i LEFT JOIN t ON s.j=t.j;
@@ -1225,7 +1225,7 @@ SELECT is_match();
 ROLLBACK TO p1;
 DROP MATERIALIZED VIEW mv;
 DROP VIEW v;
--- 3-ways outer join (full & right)
+-- 3-way outer join (full & right)
 CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
  SELECT r.i, s.i, s.j, t.j
    FROM r FULL JOIN s ON r.i=s.i RIGHT JOIN t ON s.j=t.j;
@@ -1483,7 +1483,7 @@ SELECT is_match();
 ROLLBACK TO p1;
 DROP MATERIALIZED VIEW mv;
 DROP VIEW v;
--- 3-ways outer join (full & inner)
+-- 3-way outer join (full & inner)
 CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
  SELECT r.i, s.i, s.j, t.j
    FROM r FULL JOIN s ON r.i=s.i INNER JOIN t ON s.j=t.j;
@@ -1714,7 +1714,7 @@ SELECT is_match();
 ROLLBACK TO p1;
 DROP MATERIALIZED VIEW mv;
 DROP VIEW v;
--- 3-ways outer join (left & full)
+-- 3-way outer join (left & full)
 CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
  SELECT r.i, s.i, s.j, t.j
    FROM r LEFT JOIN s ON r.i=s.i FULL JOIN t ON s.j=t.j;
@@ -2014,7 +2014,7 @@ SELECT is_match();
 ROLLBACK TO p1;
 DROP MATERIALIZED VIEW mv;
 DROP VIEW v;
--- 3-ways outer join (left & left)
+-- 3-way outer join (left & left)
 CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
  SELECT r.i, s.i, s.j, t.j
    FROM r LEFT JOIN s ON r.i=s.i LEFT JOIN t ON s.j=t.j;
@@ -2283,7 +2283,7 @@ SELECT is_match();
 ROLLBACK TO p1;
 DROP MATERIALIZED VIEW mv;
 DROP VIEW v;
--- 3-ways outer join (left & right)
+-- 3-way outer join (left & right)
 CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
  SELECT r.i, s.i, s.j, t.j
    FROM r LEFT JOIN s ON r.i=s.i RIGHT JOIN t ON s.j=t.j;
@@ -2528,7 +2528,7 @@ SELECT is_match();
 ROLLBACK TO p1;
 DROP MATERIALIZED VIEW mv;
 DROP VIEW v;
--- 3-ways outer join (left & inner)
+-- 3-way outer join (left & inner)
 CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
  SELECT r.i, s.i, s.j, t.j
    FROM r LEFT JOIN s ON r.i=s.i INNER JOIN t ON s.j=t.j;
@@ -2742,7 +2742,7 @@ SELECT is_match();
 ROLLBACK TO p1;
 DROP MATERIALIZED VIEW mv;
 DROP VIEW v;
--- 3-ways outer join (right & full)
+-- 3-way outer join (right & full)
 CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
  SELECT r.i, s.i, s.j, t.j
    FROM r RIGHT JOIN s ON r.i=s.i FULL JOIN t ON s.j=t.j;
@@ -3051,7 +3051,7 @@ SELECT is_match();
 ROLLBACK TO p1;
 DROP MATERIALIZED VIEW mv;
 DROP VIEW v;
--- 3-ways outer join (right & left)
+-- 3-way outer join (right & left)
 CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
  SELECT r.i, s.i, s.j, t.j
    FROM r RIGHT JOIN s ON r.i=s.i LEFT JOIN t ON s.j=t.j;
@@ -3333,7 +3333,7 @@ SELECT is_match();
 ROLLBACK TO p1;
 DROP MATERIALIZED VIEW mv;
 DROP VIEW v;
--- 3-ways outer join (right & right)
+-- 3-way outer join (right & right)
 CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
  SELECT r.i, s.i, s.j, t.j
    FROM r RIGHT JOIN s ON r.i=s.i RIGHT JOIN t ON s.j=t.j;
@@ -3591,7 +3591,7 @@ SELECT is_match();
 ROLLBACK TO p1;
 DROP MATERIALIZED VIEW mv;
 DROP VIEW v;
--- 3-ways outer join (inner & FULL)
+-- 3-way outer join (inner & FULL)
 CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
  SELECT r.i, s.i, s.j, t.j
    FROM r INNER JOIN s ON r.i=s.i FULL JOIN t ON s.j=t.j;
@@ -3871,7 +3871,7 @@ SELECT is_match();
 ROLLBACK TO p1;
 DROP MATERIALIZED VIEW mv;
 DROP VIEW v;
--- 3-ways outer join (inner & left)
+-- 3-way outer join (inner & left)
 CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
  SELECT r.i, s.i, s.j, t.j
    FROM r INNER JOIN s ON r.i=s.i LEFT JOIN t ON s.j=t.j;
@@ -4120,7 +4120,7 @@ SELECT is_match();
 ROLLBACK TO p1;
 DROP MATERIALIZED VIEW mv;
 DROP VIEW v;
--- 3-ways outer join (inner & right)
+-- 3-way outer join (inner & right)
 CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
  SELECT r.i, s.i, s.j, t.j
    FROM r INNER JOIN s ON r.i=s.i RIGHT JOIN t ON s.j=t.j;
@@ -4838,11 +4838,11 @@ CREATE INCREMENTAL MATERIALIZED VIEW mv(a,b) AS SELECT a.i, b.i FROM mv_base_a a
 ERROR:  Only simple equijoin is supported for IVM with outer join
 CREATE INCREMENTAL MATERIALIZED VIEW mv(a,b,k,j) AS SELECT a.i, b.i, k j FROM mv_base_a a LEFT JOIN mv_base_b b ON a.i=b.i AND k=j;
 ERROR:  Only simple equijoin is supported for IVM with outer join
--- outer join view's WHERE clause cannot contain non null-rejecting predictions
+-- outer join view's WHERE clause cannot contain non null-rejecting predicates
 CREATE INCREMENTAL MATERIALIZED VIEW mv(a,b) AS SELECT a.i, b.i FROM mv_base_a a LEFT JOIN mv_base_b b ON a.i=b.i WHERE k IS NULL;
-ERROR:  WHERE cannot contain non null-rejecting predictions for IVM with outer join
+ERROR:  WHERE cannot contain non null-rejecting predicates for IVM with outer join
 CREATE INCREMENTAL MATERIALIZED VIEW mv(a,b) AS SELECT a.i, b.i FROM mv_base_a a LEFT JOIN mv_base_b b ON a.i=b.i WHERE (k > 10 OR k = -1);
-ERROR:  WHERE cannot contain non null-rejecting predictions for IVM with outer join
+ERROR:  WHERE cannot contain non null-rejecting predicates for IVM with outer join
 -- aggregate is not supported with outer join
 CREATE INCREMENTAL MATERIALIZED VIEW mv(a,b,v) AS SELECT a.i, b.i, sum(k) FROM mv_base_a a LEFT JOIN mv_base_b b ON a.i=b.i GROUP BY a.i, b.i;
 ERROR:  aggregate is not supported with IVM together with outer join

--- a/src/test/regress/expected/incremental_matview.out
+++ b/src/test/regress/expected/incremental_matview.out
@@ -552,6 +552,4305 @@ SELECT * FROM mv_ivm_subquery ORDER BY i,j;
 (6 rows)
 
 ROLLBACK;
+-- views including NULL
+BEGIN;
+CREATE TABLE t (i int, v int);
+INSERT INTO t VALUES (1,10),(2, NULL);
+CREATE INCREMENTAL MATERIALIZED VIEW mv AS SELECT * FROM t;
+SELECT * FROM mv ORDER BY i;
+ i | v  
+---+----
+ 1 | 10
+ 2 |   
+(2 rows)
+
+UPDATE t SET v = 20 WHERE i = 2;
+SELECT * FROM mv ORDER BY i;
+ i | v  
+---+----
+ 1 | 10
+ 2 | 20
+(2 rows)
+
+ROLLBACK;
+-- support outer joins
+BEGIN;
+CREATE TABLE r (i int);
+CREATE TABLE s (i int, j int);
+CREATE TABLE t (j int);
+INSERT INTO r VALUES (1), (2), (3), (3);
+INSERT INTO s VALUES (2,1), (2,2), (3,1), (4,1), (4,2);
+INSERT INTO t VALUES (2), (3), (3);
+CREATE FUNCTION is_match() RETURNS text AS $$
+DECLARE
+x text;
+BEGIN
+ EXECUTE
+ 'SELECT CASE WHEN count(*) = 0 THEN ''OK'' ELSE ''NG'' END FROM (
+	SELECT * FROM (SELECT * FROM mv EXCEPT ALL SELECT * FROM v) v1
+	UNION ALL
+ SELECT * FROM (SELECT * FROM v EXCEPT ALL SELECT * FROM mv) v2
+ ) v' INTO x;
+ RETURN x;
+END;
+$$ LANGUAGE plpgsql;
+-- 3-ways outer join (full & full)
+CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r FULL JOIN s ON r.i=s.i FULL JOIN t ON s.j=t.j;
+CREATE VIEW v(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r FULL JOIN s ON r.i=s.i FULL JOIN t ON s.j=t.j;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |    |    |  
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |  4 |  1 |  
+   |  4 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+(9 rows)
+
+SAVEPOINT p1;
+INSERT INTO r VALUES (1),(2),(3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |    |    |  
+ 1 |    |    |  
+ 2 |  2 |  1 |  
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |  4 |  1 |  
+   |  4 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+(13 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO r VALUES (4),(5);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |    |    |  
+ 1 |    |    |  
+ 2 |  2 |  1 |  
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+ 4 |  4 |  1 |  
+ 4 |  4 |  2 | 2
+ 5 |    |    |  
+   |    |    | 3
+   |    |    | 3
+(14 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+INSERT INTO s VALUES (1,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |  1 |  3 | 3
+ 1 |  1 |  3 | 3
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |  4 |  1 |  
+   |  4 |  2 | 2
+(8 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO s VALUES (2,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |  1 |  3 | 3
+ 1 |  1 |  3 | 3
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 2 |  2 |  3 | 3
+ 2 |  2 |  3 | 3
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |  4 |  1 |  
+   |  4 |  2 | 2
+(10 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+INSERT INTO t VALUES (1),(2);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |    |    |  
+ 2 |  2 |  1 | 1
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 | 1
+ 3 |  3 |  1 | 1
+   |  4 |  1 | 1
+   |  4 |  2 | 2
+   |  4 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+(11 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO t VALUES (3),(4);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |    |    |  
+ 2 |  2 |  1 | 1
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 | 1
+ 3 |  3 |  1 | 1
+   |  4 |  1 | 1
+   |  4 |  2 | 2
+   |  4 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+   |    |    | 3
+   |    |    | 4
+(13 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM r WHERE i=1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |  4 |  1 |  
+   |  4 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+(8 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM r WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |  2 |  1 |  
+   |  2 |  2 | 2
+   |  4 |  1 |  
+   |  4 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+(8 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM r WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+   |  2 |  1 |  
+   |  2 |  2 | 2
+   |  3 |  1 |  
+   |  4 |  1 |  
+   |  4 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+(7 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM s WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |    |    |  
+ 2 |    |    |  
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |  4 |  1 |  
+   |  4 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+(8 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM s WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |    |    |  
+ 2 |    |    |  
+ 3 |    |    |  
+ 3 |    |    |  
+   |  4 |  1 |  
+   |  4 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+(8 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM s WHERE i=4;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |    |    |  
+ 2 |    |    |  
+ 3 |    |    |  
+ 3 |    |    |  
+   |    |    | 2
+   |    |    | 3
+   |    |    | 3
+(7 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM t WHERE j=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |    |    |  
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 |  
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |  4 |  1 |  
+   |  4 |  2 |  
+   |    |    | 3
+   |    |    | 3
+(9 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM t WHERE j=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |    |    |  
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 |  
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |  4 |  1 |  
+   |  4 |  2 |  
+(7 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DROP MATERIALIZED VIEW mv;
+DROP VIEW v;
+-- 3-ways outer join (full & left)
+CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r FULL JOIN s ON r.i=s.i LEFT JOIN t ON s.j=t.j;
+CREATE VIEW v(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r FULL JOIN s ON r.i=s.i LEFT JOIN t ON s.j=t.j;
+SAVEPOINT p1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |    |    |  
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |  4 |  1 |  
+   |  4 |  2 | 2
+(7 rows)
+
+INSERT INTO r VALUES (1),(2),(3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |    |    |  
+ 1 |    |    |  
+ 2 |  2 |  1 |  
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |  4 |  1 |  
+   |  4 |  2 | 2
+(11 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO r VALUES (4),(5);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |    |    |  
+ 1 |    |    |  
+ 2 |  2 |  1 |  
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+ 4 |  4 |  1 |  
+ 4 |  4 |  2 | 2
+ 5 |    |    |  
+(12 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+INSERT INTO s VALUES (1,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |  1 |  3 | 3
+ 1 |  1 |  3 | 3
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |  4 |  1 |  
+   |  4 |  2 | 2
+(8 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO s VALUES (2,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |  1 |  3 | 3
+ 1 |  1 |  3 | 3
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 2 |  2 |  3 | 3
+ 2 |  2 |  3 | 3
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |  4 |  1 |  
+   |  4 |  2 | 2
+(10 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+INSERT INTO t VALUES (1),(2);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |    |    |  
+ 2 |  2 |  1 | 1
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 | 1
+ 3 |  3 |  1 | 1
+   |  4 |  1 | 1
+   |  4 |  2 | 2
+   |  4 |  2 | 2
+(9 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO t VALUES (3),(4);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |    |    |  
+ 2 |  2 |  1 | 1
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 | 1
+ 3 |  3 |  1 | 1
+   |  4 |  1 | 1
+   |  4 |  2 | 2
+   |  4 |  2 | 2
+(9 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM r WHERE i=1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |  4 |  1 |  
+   |  4 |  2 | 2
+(6 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM r WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |  2 |  1 |  
+   |  2 |  2 | 2
+   |  4 |  1 |  
+   |  4 |  2 | 2
+(6 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM r WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+   |  2 |  1 |  
+   |  2 |  2 | 2
+   |  3 |  1 |  
+   |  4 |  1 |  
+   |  4 |  2 | 2
+(5 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM s WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |    |    |  
+ 2 |    |    |  
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |  4 |  1 |  
+   |  4 |  2 | 2
+(6 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM s WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |    |    |  
+ 2 |    |    |  
+ 3 |    |    |  
+ 3 |    |    |  
+   |  4 |  1 |  
+   |  4 |  2 | 2
+(6 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM s WHERE i=4;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |    |    |  
+ 2 |    |    |  
+ 3 |    |    |  
+ 3 |    |    |  
+(4 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM t WHERE j=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |    |    |  
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 |  
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |  4 |  1 |  
+   |  4 |  2 |  
+(7 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM t WHERE j=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |    |    |  
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 |  
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |  4 |  1 |  
+   |  4 |  2 |  
+(7 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DROP MATERIALIZED VIEW mv;
+DROP VIEW v;
+-- 3-ways outer join (full & right)
+CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r FULL JOIN s ON r.i=s.i RIGHT JOIN t ON s.j=t.j;
+CREATE VIEW v(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r FULL JOIN s ON r.i=s.i RIGHT JOIN t ON s.j=t.j;
+SAVEPOINT p1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  2 | 2
+   |  4 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+(4 rows)
+
+INSERT INTO r VALUES (1),(2),(3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+   |  4 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+(5 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO r VALUES (4),(5);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 4 |  4 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+(5 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+INSERT INTO s VALUES (1,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |  1 |  3 | 3
+ 1 |  1 |  3 | 3
+ 2 |  2 |  2 | 2
+   |  4 |  2 | 2
+(4 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO s VALUES (2,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |  1 |  3 | 3
+ 1 |  1 |  3 | 3
+ 2 |  2 |  2 | 2
+ 2 |  2 |  3 | 3
+ 2 |  2 |  3 | 3
+   |  4 |  2 | 2
+(6 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+INSERT INTO t VALUES (1),(2);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 | 1
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 | 1
+ 3 |  3 |  1 | 1
+   |  4 |  1 | 1
+   |  4 |  2 | 2
+   |  4 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+(10 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO t VALUES (3),(4);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 | 1
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 | 1
+ 3 |  3 |  1 | 1
+   |  4 |  1 | 1
+   |  4 |  2 | 2
+   |  4 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+   |    |    | 3
+   |    |    | 4
+(12 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM r WHERE i=1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  2 | 2
+   |  4 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+(4 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM r WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+   |  2 |  2 | 2
+   |  4 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+(4 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM r WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+   |  2 |  2 | 2
+   |  4 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+(4 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM s WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+   |  4 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+(3 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM s WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+   |  4 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+(3 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM s WHERE i=4;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+   |    |    | 2
+   |    |    | 3
+   |    |    | 3
+(3 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM t WHERE j=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+   |    |    | 3
+   |    |    | 3
+(2 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM t WHERE j=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+(0 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DROP MATERIALIZED VIEW mv;
+DROP VIEW v;
+-- 3-ways outer join (full & inner)
+CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r FULL JOIN s ON r.i=s.i INNER JOIN t ON s.j=t.j;
+CREATE VIEW v(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r FULL JOIN s ON r.i=s.i INNER JOIN t ON s.j=t.j;
+SAVEPOINT p1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  2 | 2
+   |  4 |  2 | 2
+(2 rows)
+
+INSERT INTO r VALUES (1),(2),(3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+   |  4 |  2 | 2
+(3 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO r VALUES (4),(5);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 4 |  4 |  2 | 2
+(3 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+INSERT INTO s VALUES (1,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |  1 |  3 | 3
+ 1 |  1 |  3 | 3
+ 2 |  2 |  2 | 2
+   |  4 |  2 | 2
+(4 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO s VALUES (2,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |  1 |  3 | 3
+ 1 |  1 |  3 | 3
+ 2 |  2 |  2 | 2
+ 2 |  2 |  3 | 3
+ 2 |  2 |  3 | 3
+   |  4 |  2 | 2
+(6 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+INSERT INTO t VALUES (1),(2);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 | 1
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 | 1
+ 3 |  3 |  1 | 1
+   |  4 |  1 | 1
+   |  4 |  2 | 2
+   |  4 |  2 | 2
+(8 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO t VALUES (3),(4);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 | 1
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 | 1
+ 3 |  3 |  1 | 1
+   |  4 |  1 | 1
+   |  4 |  2 | 2
+   |  4 |  2 | 2
+(8 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM r WHERE i=1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  2 | 2
+   |  4 |  2 | 2
+(2 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM r WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+   |  2 |  2 | 2
+   |  4 |  2 | 2
+(2 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM r WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+   |  2 |  2 | 2
+   |  4 |  2 | 2
+(2 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM s WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+   |  4 |  2 | 2
+(1 row)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM s WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+   |  4 |  2 | 2
+(1 row)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM s WHERE i=4;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+(0 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM t WHERE j=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+(0 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM t WHERE j=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+(0 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DROP MATERIALIZED VIEW mv;
+DROP VIEW v;
+-- 3-ways outer join (left & full)
+CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r LEFT JOIN s ON r.i=s.i FULL JOIN t ON s.j=t.j;
+CREATE VIEW v(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r LEFT JOIN s ON r.i=s.i FULL JOIN t ON s.j=t.j;
+SAVEPOINT p1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |    |    |  
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |    |    | 3
+   |    |    | 3
+(7 rows)
+
+INSERT INTO r VALUES (1),(2),(3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |    |    |  
+ 1 |    |    |  
+ 2 |  2 |  1 |  
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |    |    | 3
+   |    |    | 3
+(11 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO r VALUES (4),(5);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |    |    |  
+ 1 |    |    |  
+ 2 |  2 |  1 |  
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+ 4 |  4 |  1 |  
+ 4 |  4 |  2 | 2
+ 5 |    |    |  
+   |    |    | 3
+   |    |    | 3
+(14 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+INSERT INTO s VALUES (1,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |  1 |  3 | 3
+ 1 |  1 |  3 | 3
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+(6 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO s VALUES (2,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |  1 |  3 | 3
+ 1 |  1 |  3 | 3
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 2 |  2 |  3 | 3
+ 2 |  2 |  3 | 3
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+(8 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+INSERT INTO t VALUES (1),(2);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |    |    |  
+ 2 |  2 |  1 | 1
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 | 1
+ 3 |  3 |  1 | 1
+   |    |    | 3
+   |    |    | 3
+(8 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO t VALUES (3),(4);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |    |    |  
+ 2 |  2 |  1 | 1
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 | 1
+ 3 |  3 |  1 | 1
+   |    |    | 3
+   |    |    | 3
+   |    |    | 3
+   |    |    | 4
+(10 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM r WHERE i=1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |    |    | 3
+   |    |    | 3
+(6 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM r WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |    |    | 2
+   |    |    | 3
+   |    |    | 3
+(5 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM r WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+   |    |    | 2
+   |    |    | 3
+   |    |    | 3
+(3 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM s WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |    |    |  
+ 2 |    |    |  
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |    |    | 2
+   |    |    | 3
+   |    |    | 3
+(7 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM s WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |    |    |  
+ 2 |    |    |  
+ 3 |    |    |  
+ 3 |    |    |  
+   |    |    | 2
+   |    |    | 3
+   |    |    | 3
+(7 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM s WHERE i=4;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |    |    |  
+ 2 |    |    |  
+ 3 |    |    |  
+ 3 |    |    |  
+   |    |    | 2
+   |    |    | 3
+   |    |    | 3
+(7 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM t WHERE j=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |    |    |  
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 |  
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |    |    | 3
+   |    |    | 3
+(7 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM t WHERE j=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |    |    |  
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 |  
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+(5 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DROP MATERIALIZED VIEW mv;
+DROP VIEW v;
+-- 3-ways outer join (left & left)
+CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r LEFT JOIN s ON r.i=s.i LEFT JOIN t ON s.j=t.j;
+CREATE VIEW v(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r LEFT JOIN s ON r.i=s.i LEFT JOIN t ON s.j=t.j;
+SAVEPOINT p1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |    |    |  
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+(5 rows)
+
+INSERT INTO r VALUES (1),(2),(3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |    |    |  
+ 1 |    |    |  
+ 2 |  2 |  1 |  
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+(9 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO r VALUES (4),(5);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |    |    |  
+ 1 |    |    |  
+ 2 |  2 |  1 |  
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+ 4 |  4 |  1 |  
+ 4 |  4 |  2 | 2
+ 5 |    |    |  
+(12 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+INSERT INTO s VALUES (1,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |  1 |  3 | 3
+ 1 |  1 |  3 | 3
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+(6 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO s VALUES (2,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |  1 |  3 | 3
+ 1 |  1 |  3 | 3
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 2 |  2 |  3 | 3
+ 2 |  2 |  3 | 3
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+(8 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+INSERT INTO t VALUES (1),(2);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |    |    |  
+ 2 |  2 |  1 | 1
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 | 1
+ 3 |  3 |  1 | 1
+(6 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO t VALUES (3),(4);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |    |    |  
+ 2 |  2 |  1 | 1
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 | 1
+ 3 |  3 |  1 | 1
+(6 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM r WHERE i=1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+(4 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM r WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+(2 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM r WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+(0 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM s WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |    |    |  
+ 2 |    |    |  
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+(4 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM s WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |    |    |  
+ 2 |    |    |  
+ 3 |    |    |  
+ 3 |    |    |  
+(4 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM s WHERE i=4;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |    |    |  
+ 2 |    |    |  
+ 3 |    |    |  
+ 3 |    |    |  
+(4 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM t WHERE j=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |    |    |  
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 |  
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+(5 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM t WHERE j=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |    |    |  
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 |  
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+(5 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DROP MATERIALIZED VIEW mv;
+DROP VIEW v;
+-- 3-ways outer join (left & right)
+CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r LEFT JOIN s ON r.i=s.i RIGHT JOIN t ON s.j=t.j;
+CREATE VIEW v(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r LEFT JOIN s ON r.i=s.i RIGHT JOIN t ON s.j=t.j;
+SAVEPOINT p1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+(3 rows)
+
+INSERT INTO r VALUES (1),(2),(3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+(4 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO r VALUES (4),(5);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 4 |  4 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+(5 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+INSERT INTO s VALUES (1,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |  1 |  3 | 3
+ 1 |  1 |  3 | 3
+ 2 |  2 |  2 | 2
+(3 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO s VALUES (2,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |  1 |  3 | 3
+ 1 |  1 |  3 | 3
+ 2 |  2 |  2 | 2
+ 2 |  2 |  3 | 3
+ 2 |  2 |  3 | 3
+(5 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+INSERT INTO t VALUES (1),(2);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 | 1
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 | 1
+ 3 |  3 |  1 | 1
+   |    |    | 3
+   |    |    | 3
+(7 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO t VALUES (3),(4);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 | 1
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 | 1
+ 3 |  3 |  1 | 1
+   |    |    | 3
+   |    |    | 3
+   |    |    | 3
+   |    |    | 4
+(9 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM r WHERE i=1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+(3 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM r WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+   |    |    | 2
+   |    |    | 3
+   |    |    | 3
+(3 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM r WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+   |    |    | 2
+   |    |    | 3
+   |    |    | 3
+(3 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM s WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+   |    |    | 2
+   |    |    | 3
+   |    |    | 3
+(3 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM s WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+   |    |    | 2
+   |    |    | 3
+   |    |    | 3
+(3 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM s WHERE i=4;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+   |    |    | 2
+   |    |    | 3
+   |    |    | 3
+(3 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM t WHERE j=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+   |    |    | 3
+   |    |    | 3
+(2 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM t WHERE j=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+(0 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DROP MATERIALIZED VIEW mv;
+DROP VIEW v;
+-- 3-ways outer join (left & inner)
+CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r LEFT JOIN s ON r.i=s.i INNER JOIN t ON s.j=t.j;
+CREATE VIEW v(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r LEFT JOIN s ON r.i=s.i INNER JOIN t ON s.j=t.j;
+SAVEPOINT p1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  2 | 2
+(1 row)
+
+INSERT INTO r VALUES (1),(2),(3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+(2 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO r VALUES (4),(5);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 4 |  4 |  2 | 2
+(3 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+INSERT INTO s VALUES (1,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |  1 |  3 | 3
+ 1 |  1 |  3 | 3
+ 2 |  2 |  2 | 2
+(3 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO s VALUES (2,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |  1 |  3 | 3
+ 1 |  1 |  3 | 3
+ 2 |  2 |  2 | 2
+ 2 |  2 |  3 | 3
+ 2 |  2 |  3 | 3
+(5 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+INSERT INTO t VALUES (1),(2);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 | 1
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 | 1
+ 3 |  3 |  1 | 1
+(5 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO t VALUES (3),(4);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 | 1
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 | 1
+ 3 |  3 |  1 | 1
+(5 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM r WHERE i=1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  2 | 2
+(1 row)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM r WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+(0 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM r WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+(0 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM s WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+(0 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM s WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+(0 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM s WHERE i=4;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+(0 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM t WHERE j=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+(0 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM t WHERE j=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+(0 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DROP MATERIALIZED VIEW mv;
+DROP VIEW v;
+-- 3-ways outer join (right & full)
+CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r RIGHT JOIN s ON r.i=s.i FULL JOIN t ON s.j=t.j;
+CREATE VIEW v(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r RIGHT JOIN s ON r.i=s.i FULL JOIN t ON s.j=t.j;
+SAVEPOINT p1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |  4 |  1 |  
+   |  4 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+(8 rows)
+
+INSERT INTO r VALUES (1),(2),(3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 |  
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |  4 |  1 |  
+   |  4 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+(11 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO r VALUES (4),(5);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 |  
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+ 4 |  4 |  1 |  
+ 4 |  4 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+(11 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+INSERT INTO s VALUES (1,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |  1 |  3 | 3
+ 1 |  1 |  3 | 3
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |  4 |  1 |  
+   |  4 |  2 | 2
+(8 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO s VALUES (2,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |  1 |  3 | 3
+ 1 |  1 |  3 | 3
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 2 |  2 |  3 | 3
+ 2 |  2 |  3 | 3
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |  4 |  1 |  
+   |  4 |  2 | 2
+(10 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+INSERT INTO t VALUES (1),(2);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 | 1
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 | 1
+ 3 |  3 |  1 | 1
+   |  4 |  1 | 1
+   |  4 |  2 | 2
+   |  4 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+(10 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO t VALUES (3),(4);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 | 1
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 | 1
+ 3 |  3 |  1 | 1
+   |  4 |  1 | 1
+   |  4 |  2 | 2
+   |  4 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+   |    |    | 3
+   |    |    | 4
+(12 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM r WHERE i=1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |  4 |  1 |  
+   |  4 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+(8 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM r WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |  2 |  1 |  
+   |  2 |  2 | 2
+   |  4 |  1 |  
+   |  4 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+(8 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM r WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+   |  2 |  1 |  
+   |  2 |  2 | 2
+   |  3 |  1 |  
+   |  4 |  1 |  
+   |  4 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+(7 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM s WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |  4 |  1 |  
+   |  4 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+(6 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM s WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+   |  4 |  1 |  
+   |  4 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+(4 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM s WHERE i=4;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+   |    |    | 2
+   |    |    | 3
+   |    |    | 3
+(3 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM t WHERE j=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 |  
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |  4 |  1 |  
+   |  4 |  2 |  
+   |    |    | 3
+   |    |    | 3
+(8 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM t WHERE j=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 |  
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |  4 |  1 |  
+   |  4 |  2 |  
+(6 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DROP MATERIALIZED VIEW mv;
+DROP VIEW v;
+-- 3-ways outer join (right & left)
+CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r RIGHT JOIN s ON r.i=s.i LEFT JOIN t ON s.j=t.j;
+CREATE VIEW v(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r RIGHT JOIN s ON r.i=s.i LEFT JOIN t ON s.j=t.j;
+SAVEPOINT p1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |  4 |  1 |  
+   |  4 |  2 | 2
+(6 rows)
+
+INSERT INTO r VALUES (1),(2),(3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 |  
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |  4 |  1 |  
+   |  4 |  2 | 2
+(9 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO r VALUES (4),(5);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 |  
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+ 4 |  4 |  1 |  
+ 4 |  4 |  2 | 2
+(9 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+INSERT INTO s VALUES (1,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |  1 |  3 | 3
+ 1 |  1 |  3 | 3
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |  4 |  1 |  
+   |  4 |  2 | 2
+(8 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO s VALUES (2,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |  1 |  3 | 3
+ 1 |  1 |  3 | 3
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 2 |  2 |  3 | 3
+ 2 |  2 |  3 | 3
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |  4 |  1 |  
+   |  4 |  2 | 2
+(10 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+INSERT INTO t VALUES (1),(2);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 | 1
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 | 1
+ 3 |  3 |  1 | 1
+   |  4 |  1 | 1
+   |  4 |  2 | 2
+   |  4 |  2 | 2
+(8 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO t VALUES (3),(4);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 | 1
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 | 1
+ 3 |  3 |  1 | 1
+   |  4 |  1 | 1
+   |  4 |  2 | 2
+   |  4 |  2 | 2
+(8 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM r WHERE i=1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |  4 |  1 |  
+   |  4 |  2 | 2
+(6 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM r WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |  2 |  1 |  
+   |  2 |  2 | 2
+   |  4 |  1 |  
+   |  4 |  2 | 2
+(6 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM r WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+   |  2 |  1 |  
+   |  2 |  2 | 2
+   |  3 |  1 |  
+   |  4 |  1 |  
+   |  4 |  2 | 2
+(5 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM s WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |  4 |  1 |  
+   |  4 |  2 | 2
+(4 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM s WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+   |  4 |  1 |  
+   |  4 |  2 | 2
+(2 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM s WHERE i=4;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+(0 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM t WHERE j=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 |  
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |  4 |  1 |  
+   |  4 |  2 |  
+(6 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM t WHERE j=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 |  
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |  4 |  1 |  
+   |  4 |  2 |  
+(6 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DROP MATERIALIZED VIEW mv;
+DROP VIEW v;
+-- 3-ways outer join (right & right)
+CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r RIGHT JOIN s ON r.i=s.i RIGHT JOIN t ON s.j=t.j;
+CREATE VIEW v(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r RIGHT JOIN s ON r.i=s.i RIGHT JOIN t ON s.j=t.j;
+SAVEPOINT p1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  2 | 2
+   |  4 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+(4 rows)
+
+INSERT INTO r VALUES (1),(2),(3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+   |  4 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+(5 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO r VALUES (4),(5);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 4 |  4 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+(5 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+INSERT INTO s VALUES (1,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |  1 |  3 | 3
+ 1 |  1 |  3 | 3
+ 2 |  2 |  2 | 2
+   |  4 |  2 | 2
+(4 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO s VALUES (2,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |  1 |  3 | 3
+ 1 |  1 |  3 | 3
+ 2 |  2 |  2 | 2
+ 2 |  2 |  3 | 3
+ 2 |  2 |  3 | 3
+   |  4 |  2 | 2
+(6 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+INSERT INTO t VALUES (1),(2);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 | 1
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 | 1
+ 3 |  3 |  1 | 1
+   |  4 |  1 | 1
+   |  4 |  2 | 2
+   |  4 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+(10 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO t VALUES (3),(4);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 | 1
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 | 1
+ 3 |  3 |  1 | 1
+   |  4 |  1 | 1
+   |  4 |  2 | 2
+   |  4 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+   |    |    | 3
+   |    |    | 4
+(12 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM r WHERE i=1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  2 | 2
+   |  4 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+(4 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM r WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+   |  2 |  2 | 2
+   |  4 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+(4 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM r WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+   |  2 |  2 | 2
+   |  4 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+(4 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM s WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+   |  4 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+(3 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM s WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+   |  4 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+(3 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM s WHERE i=4;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+   |    |    | 2
+   |    |    | 3
+   |    |    | 3
+(3 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM t WHERE j=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+   |    |    | 3
+   |    |    | 3
+(2 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM t WHERE j=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+(0 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DROP MATERIALIZED VIEW mv;
+DROP VIEW v;
+-- 3-ways outer join (inner & FULL)
+CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r INNER JOIN s ON r.i=s.i FULL JOIN t ON s.j=t.j;
+CREATE VIEW v(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r INNER JOIN s ON r.i=s.i FULL JOIN t ON s.j=t.j;
+SAVEPOINT p1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |    |    | 3
+   |    |    | 3
+(6 rows)
+
+INSERT INTO r VALUES (1),(2),(3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 |  
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |    |    | 3
+   |    |    | 3
+(9 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO r VALUES (4),(5);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 |  
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+ 4 |  4 |  1 |  
+ 4 |  4 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+(11 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+INSERT INTO s VALUES (1,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |  1 |  3 | 3
+ 1 |  1 |  3 | 3
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+(6 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO s VALUES (2,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |  1 |  3 | 3
+ 1 |  1 |  3 | 3
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 2 |  2 |  3 | 3
+ 2 |  2 |  3 | 3
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+(8 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+INSERT INTO t VALUES (1),(2);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 | 1
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 | 1
+ 3 |  3 |  1 | 1
+   |    |    | 3
+   |    |    | 3
+(7 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO t VALUES (3),(4);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 | 1
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 | 1
+ 3 |  3 |  1 | 1
+   |    |    | 3
+   |    |    | 3
+   |    |    | 3
+   |    |    | 4
+(9 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM r WHERE i=1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |    |    | 3
+   |    |    | 3
+(6 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM r WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |    |    | 2
+   |    |    | 3
+   |    |    | 3
+(5 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM r WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+   |    |    | 2
+   |    |    | 3
+   |    |    | 3
+(3 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM s WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |    |    | 2
+   |    |    | 3
+   |    |    | 3
+(5 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM s WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+   |    |    | 2
+   |    |    | 3
+   |    |    | 3
+(3 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM s WHERE i=4;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+   |    |    | 2
+   |    |    | 3
+   |    |    | 3
+(3 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM t WHERE j=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 |  
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+   |    |    | 3
+   |    |    | 3
+(6 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM t WHERE j=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 |  
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+(4 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DROP MATERIALIZED VIEW mv;
+DROP VIEW v;
+-- 3-ways outer join (inner & left)
+CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r INNER JOIN s ON r.i=s.i LEFT JOIN t ON s.j=t.j;
+CREATE VIEW v(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r INNER JOIN s ON r.i=s.i LEFT JOIN t ON s.j=t.j;
+SAVEPOINT p1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+(4 rows)
+
+INSERT INTO r VALUES (1),(2),(3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 |  
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+(7 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO r VALUES (4),(5);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 |  
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+ 4 |  4 |  1 |  
+ 4 |  4 |  2 | 2
+(9 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+INSERT INTO s VALUES (1,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |  1 |  3 | 3
+ 1 |  1 |  3 | 3
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+(6 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO s VALUES (2,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |  1 |  3 | 3
+ 1 |  1 |  3 | 3
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 2 |  2 |  3 | 3
+ 2 |  2 |  3 | 3
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+(8 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+INSERT INTO t VALUES (1),(2);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 | 1
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 | 1
+ 3 |  3 |  1 | 1
+(5 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO t VALUES (3),(4);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 | 1
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 | 1
+ 3 |  3 |  1 | 1
+(5 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM r WHERE i=1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+(4 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM r WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+(2 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM r WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+(0 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM s WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+(2 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM s WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+(0 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM s WHERE i=4;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+(0 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM t WHERE j=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 |  
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+(4 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM t WHERE j=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 |  
+ 2 |  2 |  2 |  
+ 3 |  3 |  1 |  
+ 3 |  3 |  1 |  
+(4 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DROP MATERIALIZED VIEW mv;
+DROP VIEW v;
+-- 3-ways outer join (inner & right)
+CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r INNER JOIN s ON r.i=s.i RIGHT JOIN t ON s.j=t.j;
+CREATE VIEW v(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r INNER JOIN s ON r.i=s.i RIGHT JOIN t ON s.j=t.j;
+SAVEPOINT p1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+(3 rows)
+
+INSERT INTO r VALUES (1),(2),(3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+(4 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO r VALUES (4),(5);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 4 |  4 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+(5 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+INSERT INTO s VALUES (1,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |  1 |  3 | 3
+ 1 |  1 |  3 | 3
+ 2 |  2 |  2 | 2
+(3 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO s VALUES (2,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 1 |  1 |  3 | 3
+ 1 |  1 |  3 | 3
+ 2 |  2 |  2 | 2
+ 2 |  2 |  3 | 3
+ 2 |  2 |  3 | 3
+(5 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+INSERT INTO t VALUES (1),(2);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 | 1
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 | 1
+ 3 |  3 |  1 | 1
+   |    |    | 3
+   |    |    | 3
+(7 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO t VALUES (3),(4);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  1 | 1
+ 2 |  2 |  2 | 2
+ 2 |  2 |  2 | 2
+ 3 |  3 |  1 | 1
+ 3 |  3 |  1 | 1
+   |    |    | 3
+   |    |    | 3
+   |    |    | 3
+   |    |    | 4
+(9 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM r WHERE i=1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+ 2 |  2 |  2 | 2
+   |    |    | 3
+   |    |    | 3
+(3 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM r WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+   |    |    | 2
+   |    |    | 3
+   |    |    | 3
+(3 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM r WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+   |    |    | 2
+   |    |    | 3
+   |    |    | 3
+(3 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM s WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+   |    |    | 2
+   |    |    | 3
+   |    |    | 3
+(3 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM s WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+   |    |    | 2
+   |    |    | 3
+   |    |    | 3
+(3 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM s WHERE i=4;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+   |    |    | 2
+   |    |    | 3
+   |    |    | 3
+(3 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM t WHERE j=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+   |    |    | 3
+   |    |    | 3
+(2 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM t WHERE j=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+ r | si | sj | t 
+---+----+----+---
+(0 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DROP MATERIALIZED VIEW mv;
+DROP VIEW v;
+-- outer join with WHERE clause
+CREATE INCREMENTAL MATERIALIZED VIEW mv(r, s) AS
+ SELECT r.i, s.i
+   FROM r FULL JOIN s ON r.i=s.i WHERE s.i > 0;
+CREATE VIEW v(r, s) AS
+ SELECT r.i, s.i
+   FROM r FULL JOIN s ON r.i=s.i WHERE s.i > 0;
+SAVEPOINT p1;
+SELECT * FROM mv ORDER BY r, s;
+ r | s 
+---+---
+ 2 | 2
+ 2 | 2
+ 3 | 3
+ 3 | 3
+   | 4
+   | 4
+(6 rows)
+
+INSERT INTO r VALUES (1),(2),(3);
+SELECT * FROM mv ORDER BY r, s;
+ r | s 
+---+---
+ 2 | 2
+ 2 | 2
+ 2 | 2
+ 2 | 2
+ 3 | 3
+ 3 | 3
+ 3 | 3
+   | 4
+   | 4
+(9 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO r VALUES (4),(5);
+SELECT * FROM mv ORDER BY r, s;
+ r | s 
+---+---
+ 2 | 2
+ 2 | 2
+ 2 | 2
+ 2 | 2
+ 3 | 3
+ 3 | 3
+ 3 | 3
+ 4 | 4
+ 4 | 4
+(9 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+INSERT INTO s VALUES (1,3);
+SELECT * FROM mv ORDER BY r, s;
+ r | s 
+---+---
+ 1 | 1
+ 2 | 2
+ 2 | 2
+ 3 | 3
+ 3 | 3
+   | 4
+   | 4
+(7 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO s VALUES (2,3);
+SELECT * FROM mv ORDER BY r, s;
+ r | s 
+---+---
+ 1 | 1
+ 2 | 2
+ 2 | 2
+ 2 | 2
+ 3 | 3
+ 3 | 3
+   | 4
+   | 4
+(8 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM r WHERE i=1;
+SELECT * FROM mv ORDER BY r, s;
+ r | s 
+---+---
+ 2 | 2
+ 2 | 2
+ 3 | 3
+ 3 | 3
+   | 4
+   | 4
+(6 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM r WHERE i=2;
+SELECT * FROM mv ORDER BY r, s;
+ r | s 
+---+---
+ 3 | 3
+ 3 | 3
+   | 2
+   | 2
+   | 4
+   | 4
+(6 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM r WHERE i=3;
+SELECT * FROM mv ORDER BY r, s;
+ r | s 
+---+---
+   | 2
+   | 2
+   | 3
+   | 4
+   | 4
+(5 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM s WHERE i=2;
+SELECT * FROM mv ORDER BY r, s;
+ r | s 
+---+---
+ 3 | 3
+ 3 | 3
+   | 4
+   | 4
+(4 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM s WHERE i=3;
+SELECT * FROM mv ORDER BY r, s;
+ r | s 
+---+---
+   | 4
+   | 4
+(2 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM s WHERE i=4;
+SELECT * FROM mv ORDER BY r, s;
+ r | s 
+---+---
+(0 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DROP MATERIALIZED VIEW mv;
+DROP VIEW v;
+-- self outer join
+CREATE INCREMENTAL MATERIALIZED VIEW mv(r1, r2) AS
+ SELECT r.i, r2.i
+   FROM r FULL JOIN r as r2 ON r.i=r2.i;
+CREATE VIEW v(r1, r2) AS
+ SELECT r.i, r2.i
+   FROM r FULL JOIN r as r2 ON r.i=r2.i;
+SAVEPOINT p1;
+SELECT * FROM mv ORDER BY r1, r2;
+ r1 | r2 
+----+----
+  1 |  1
+  2 |  2
+  3 |  3
+  3 |  3
+  3 |  3
+  3 |  3
+(6 rows)
+
+INSERT INTO r VALUES (1),(2),(3);
+SELECT * FROM mv ORDER BY r1, r2;
+ r1 | r2 
+----+----
+  1 |  1
+  1 |  1
+  1 |  1
+  1 |  1
+  2 |  2
+  2 |  2
+  2 |  2
+  2 |  2
+  3 |  3
+  3 |  3
+  3 |  3
+  3 |  3
+  3 |  3
+  3 |  3
+  3 |  3
+  3 |  3
+  3 |  3
+(17 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+INSERT INTO r VALUES (4),(5);
+SELECT * FROM mv ORDER BY r1, r2;
+ r1 | r2 
+----+----
+  1 |  1
+  1 |  1
+  1 |  1
+  1 |  1
+  2 |  2
+  2 |  2
+  2 |  2
+  2 |  2
+  3 |  3
+  3 |  3
+  3 |  3
+  3 |  3
+  3 |  3
+  3 |  3
+  3 |  3
+  3 |  3
+  3 |  3
+  4 |  4
+  5 |  5
+(19 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DELETE FROM r WHERE i=1;
+SELECT * FROM mv ORDER BY r1, r2;
+ r1 | r2 
+----+----
+  2 |  2
+  3 |  3
+  3 |  3
+  3 |  3
+  3 |  3
+(5 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM r WHERE i=2;
+SELECT * FROM mv ORDER BY r1, r2;
+ r1 | r2 
+----+----
+  3 |  3
+  3 |  3
+  3 |  3
+  3 |  3
+(4 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+DELETE FROM r WHERE i=3;
+SELECT * FROM mv ORDER BY r1, r2;
+ r1 | r2 
+----+----
+(0 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DROP MATERIALIZED VIEW mv;
+DROP VIEW v;
+-- support simultaneous table changes on outer join
+CREATE INCREMENTAL MATERIALIZED VIEW mv(r, s) AS
+ SELECT r.i, s.i
+   FROM r FULL JOIN s ON r.i=s.i;
+CREATE VIEW v(r, s) AS
+ SELECT r.i, s.i
+   FROM r FULL JOIN s ON r.i=s.i;
+SAVEPOINT p1;
+SELECT * FROM mv ORDER BY r, s;
+ r | s 
+---+---
+ 1 |  
+ 2 | 2
+ 2 | 2
+ 3 | 3
+ 3 | 3
+   | 4
+   | 4
+(7 rows)
+
+WITH
+ ri AS (INSERT INTO r VALUES (1),(2),(3) RETURNING 0),
+ si AS (INSERT INTO s VALUES (1,3) RETURNING 0)
+SELECT;
+--
+(1 row)
+
+SELECT * FROM mv ORDER BY r, s;
+ r | s 
+---+---
+ 1 | 1
+ 1 | 1
+ 2 | 2
+ 2 | 2
+ 2 | 2
+ 2 | 2
+ 3 | 3
+ 3 | 3
+ 3 | 3
+   | 4
+   | 4
+(11 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+WITH
+ rd AS (DELETE FROM r WHERE i=1 RETURNING 0),
+ sd AS (DELETE FROM s WHERE i=2 RETURNING 0)
+SELECT;
+--
+(1 row)
+
+SELECT * FROM mv ORDER BY r, s;
+ r | s 
+---+---
+ 2 |  
+ 3 | 3
+ 3 | 3
+   | 4
+   | 4
+(5 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DROP MATERIALIZED VIEW mv;
+DROP VIEW v;
+-- multiple change of the same table on outer join
+CREATE INCREMENTAL MATERIALIZED VIEW mv(r, s) AS
+ SELECT r.i, s.i
+   FROM r FULL JOIN s ON r.i=s.i;
+CREATE VIEW v(r, s) AS
+ SELECT r.i, s.i
+   FROM r FULL JOIN s ON r.i=s.i;
+SAVEPOINT p1;
+SELECT * FROM mv ORDER BY r, s;
+ r | s 
+---+---
+ 1 |  
+ 2 | 2
+ 2 | 2
+ 3 | 3
+ 3 | 3
+   | 4
+   | 4
+(7 rows)
+
+WITH
+ ri1 AS (INSERT INTO r VALUES (1),(2),(3) RETURNING 0),
+ ri2 AS (INSERT INTO r VALUES (4),(5) RETURNING 0),
+ rd AS (DELETE FROM r WHERE i IN (3,4) RETURNING 0)
+SELECT;
+--
+(1 row)
+
+SELECT * FROM mv ORDER BY r, s;
+ r | s 
+---+---
+ 1 |  
+ 1 |  
+ 2 | 2
+ 2 | 2
+ 2 | 2
+ 2 | 2
+ 3 | 3
+ 4 | 4
+ 4 | 4
+ 5 |  
+(10 rows)
+
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+DROP MATERIALIZED VIEW mv;
+DROP VIEW v;
+ROLLBACK;
+-- outer join view's targetlist must contain vars in the join conditions
+CREATE INCREMENTAL MATERIALIZED VIEW mv AS SELECT a.i FROM mv_base_a a LEFT JOIN mv_base_b b ON a.i=b.i;
+ERROR:  targetlist must contain vars in the join condition for IVM with outer join
+CREATE INCREMENTAL MATERIALIZED VIEW mv AS SELECT a.i,j,k FROM mv_base_a a LEFT JOIN mv_base_b b USING(i);
+ERROR:  targetlist must contain vars in the join condition for IVM with outer join
+-- outer join view's targetlist cannot contain non strict functions
+CREATE INCREMENTAL MATERIALIZED VIEW mv AS SELECT a.i, b.i, (k > 10 OR k = -1) FROM mv_base_a a LEFT JOIN mv_base_b b ON a.i=b.i;
+ERROR:  targetlist cannot contain non strict functions for IVM with outer join
+CREATE INCREMENTAL MATERIALIZED VIEW mv AS SELECT a.i, b.i, CASE WHEN k>0 THEN 1 ELSE 0 END FROM mv_base_a a LEFT JOIN mv_base_b b ON a.i=b.i;
+ERROR:  targetlist cannot contain non strict functions for IVM with outer join
+-- outer join supports only simple equijoin
+CREATE INCREMENTAL MATERIALIZED VIEW mv(a,b) AS SELECT a.i, b.i FROM mv_base_a a LEFT JOIN mv_base_b b ON a.i>b.i;
+ERROR:  Only simple equijoin is supported for IVM with outer join
+CREATE INCREMENTAL MATERIALIZED VIEW mv(a,b,k,j) AS SELECT a.i, b.i, k j FROM mv_base_a a LEFT JOIN mv_base_b b ON a.i=b.i AND k=j;
+ERROR:  Only simple equijoin is supported for IVM with outer join
+-- outer join view's WHERE clause cannot contain non null-rejecting predictions
+CREATE INCREMENTAL MATERIALIZED VIEW mv(a,b) AS SELECT a.i, b.i FROM mv_base_a a LEFT JOIN mv_base_b b ON a.i=b.i WHERE k IS NULL;
+ERROR:  WHERE cannot contain non null-rejecting predictions for IVM with outer join
+CREATE INCREMENTAL MATERIALIZED VIEW mv(a,b) AS SELECT a.i, b.i FROM mv_base_a a LEFT JOIN mv_base_b b ON a.i=b.i WHERE (k > 10 OR k = -1);
+ERROR:  WHERE cannot contain non null-rejecting predictions for IVM with outer join
+-- aggregate is not supported with outer join
+CREATE INCREMENTAL MATERIALIZED VIEW mv(a,b,v) AS SELECT a.i, b.i, sum(k) FROM mv_base_a a LEFT JOIN mv_base_b b ON a.i=b.i GROUP BY a.i, b.i;
+ERROR:  aggregate is not supported with IVM together with outer join
+-- subquery is not supported with outer join
+CREATE INCREMENTAL MATERIALIZED VIEW mv(a,b) AS SELECT a.i, b.i FROM mv_base_a a LEFT JOIN (SELECT * FROM mv_base_b) b ON a.i=b.i;
+ERROR:  subquery is not supported with IVM together with outer join
+CREATE INCREMENTAL MATERIALIZED VIEW mv(a,b) AS SELECT a.i, b.i FROM mv_base_a a LEFT JOIN mv_base_b b ON a.i=b.i WHERE EXISTS (SELECT 1 FROM mv_base_b b2 WHERE a.j = b.k);
+ERROR:  subquery is not supported by IVM together with outer join
 -- contain system column
 CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm01 AS SELECT i,j,xmin FROM mv_base_a;
 ERROR:  system column is not supported with IVM

--- a/src/test/regress/sql/incremental_matview.sql
+++ b/src/test/regress/sql/incremental_matview.sql
@@ -973,7 +973,74 @@ ROLLBACK TO p1;
 DROP MATERIALIZED VIEW mv;
 DROP VIEW v;
 
--- 3-way outer join (inner & FULL)
+-- 3-way outer join (right & inner)
+CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r RIGHT JOIN s ON r.i=s.i INNER JOIN t ON s.j=t.j;
+CREATE VIEW v(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r RIGHT JOIN s ON r.i=s.i INNER JOIN t ON s.j=t.j;
+SAVEPOINT p1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+
+INSERT INTO r VALUES (1),(2),(3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+INSERT INTO r VALUES (4),(5);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+INSERT INTO s VALUES (1,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+INSERT INTO s VALUES (2,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+INSERT INTO t VALUES (1),(2);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+INSERT INTO t VALUES (3),(4);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM r WHERE i=1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM r WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM r WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM s WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM s WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM s WHERE i=4;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM t WHERE j=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM t WHERE j=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DROP MATERIALIZED VIEW mv;
+DROP VIEW v;
+
+-- 3-way outer join (inner & full)
 CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
  SELECT r.i, s.i, s.j, t.j
    FROM r INNER JOIN s ON r.i=s.i FULL JOIN t ON s.j=t.j;

--- a/src/test/regress/sql/incremental_matview.sql
+++ b/src/test/regress/sql/incremental_matview.sql
@@ -203,6 +203,1136 @@ SELECT * FROM mv_ivm_subquery ORDER BY i,j;
 
 ROLLBACK;
 
+-- views including NULL
+BEGIN;
+CREATE TABLE t (i int, v int);
+INSERT INTO t VALUES (1,10),(2, NULL);
+CREATE INCREMENTAL MATERIALIZED VIEW mv AS SELECT * FROM t;
+SELECT * FROM mv ORDER BY i;
+UPDATE t SET v = 20 WHERE i = 2;
+SELECT * FROM mv ORDER BY i;
+ROLLBACK;
+
+-- support outer joins
+BEGIN;
+CREATE TABLE r (i int);
+CREATE TABLE s (i int, j int);
+CREATE TABLE t (j int);
+INSERT INTO r VALUES (1), (2), (3), (3);
+INSERT INTO s VALUES (2,1), (2,2), (3,1), (4,1), (4,2);
+INSERT INTO t VALUES (2), (3), (3);
+
+CREATE FUNCTION is_match() RETURNS text AS $$
+DECLARE
+x text;
+BEGIN
+ EXECUTE
+ 'SELECT CASE WHEN count(*) = 0 THEN ''OK'' ELSE ''NG'' END FROM (
+	SELECT * FROM (SELECT * FROM mv EXCEPT ALL SELECT * FROM v) v1
+	UNION ALL
+ SELECT * FROM (SELECT * FROM v EXCEPT ALL SELECT * FROM mv) v2
+ ) v' INTO x;
+ RETURN x;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 3-ways outer join (full & full)
+CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r FULL JOIN s ON r.i=s.i FULL JOIN t ON s.j=t.j;
+CREATE VIEW v(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r FULL JOIN s ON r.i=s.i FULL JOIN t ON s.j=t.j;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SAVEPOINT p1;
+
+INSERT INTO r VALUES (1),(2),(3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+INSERT INTO r VALUES (4),(5);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+INSERT INTO s VALUES (1,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+INSERT INTO s VALUES (2,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+INSERT INTO t VALUES (1),(2);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+INSERT INTO t VALUES (3),(4);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM r WHERE i=1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM r WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM r WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM s WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM s WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM s WHERE i=4;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM t WHERE j=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM t WHERE j=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DROP MATERIALIZED VIEW mv;
+DROP VIEW v;
+
+-- 3-ways outer join (full & left)
+CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r FULL JOIN s ON r.i=s.i LEFT JOIN t ON s.j=t.j;
+CREATE VIEW v(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r FULL JOIN s ON r.i=s.i LEFT JOIN t ON s.j=t.j;
+SAVEPOINT p1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+
+INSERT INTO r VALUES (1),(2),(3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+INSERT INTO r VALUES (4),(5);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+INSERT INTO s VALUES (1,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+INSERT INTO s VALUES (2,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+INSERT INTO t VALUES (1),(2);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+INSERT INTO t VALUES (3),(4);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM r WHERE i=1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM r WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM r WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM s WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM s WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM s WHERE i=4;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM t WHERE j=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM t WHERE j=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DROP MATERIALIZED VIEW mv;
+DROP VIEW v;
+
+-- 3-ways outer join (full & right)
+CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r FULL JOIN s ON r.i=s.i RIGHT JOIN t ON s.j=t.j;
+CREATE VIEW v(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r FULL JOIN s ON r.i=s.i RIGHT JOIN t ON s.j=t.j;
+SAVEPOINT p1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+
+INSERT INTO r VALUES (1),(2),(3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+INSERT INTO r VALUES (4),(5);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+INSERT INTO s VALUES (1,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+INSERT INTO s VALUES (2,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+INSERT INTO t VALUES (1),(2);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+INSERT INTO t VALUES (3),(4);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM r WHERE i=1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM r WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM r WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM s WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM s WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM s WHERE i=4;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM t WHERE j=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM t WHERE j=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DROP MATERIALIZED VIEW mv;
+DROP VIEW v;
+
+-- 3-ways outer join (full & inner)
+CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r FULL JOIN s ON r.i=s.i INNER JOIN t ON s.j=t.j;
+CREATE VIEW v(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r FULL JOIN s ON r.i=s.i INNER JOIN t ON s.j=t.j;
+SAVEPOINT p1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+
+INSERT INTO r VALUES (1),(2),(3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+INSERT INTO r VALUES (4),(5);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+INSERT INTO s VALUES (1,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+INSERT INTO s VALUES (2,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+INSERT INTO t VALUES (1),(2);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+INSERT INTO t VALUES (3),(4);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM r WHERE i=1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM r WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM r WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM s WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM s WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM s WHERE i=4;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM t WHERE j=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM t WHERE j=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DROP MATERIALIZED VIEW mv;
+DROP VIEW v;
+
+-- 3-ways outer join (left & full)
+CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r LEFT JOIN s ON r.i=s.i FULL JOIN t ON s.j=t.j;
+CREATE VIEW v(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r LEFT JOIN s ON r.i=s.i FULL JOIN t ON s.j=t.j;
+SAVEPOINT p1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+
+INSERT INTO r VALUES (1),(2),(3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+INSERT INTO r VALUES (4),(5);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+INSERT INTO s VALUES (1,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+INSERT INTO s VALUES (2,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+INSERT INTO t VALUES (1),(2);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+INSERT INTO t VALUES (3),(4);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM r WHERE i=1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM r WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM r WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM s WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM s WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM s WHERE i=4;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM t WHERE j=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM t WHERE j=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DROP MATERIALIZED VIEW mv;
+DROP VIEW v;
+
+-- 3-ways outer join (left & left)
+CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r LEFT JOIN s ON r.i=s.i LEFT JOIN t ON s.j=t.j;
+CREATE VIEW v(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r LEFT JOIN s ON r.i=s.i LEFT JOIN t ON s.j=t.j;
+SAVEPOINT p1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+
+INSERT INTO r VALUES (1),(2),(3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+INSERT INTO r VALUES (4),(5);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+INSERT INTO s VALUES (1,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+INSERT INTO s VALUES (2,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+INSERT INTO t VALUES (1),(2);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+INSERT INTO t VALUES (3),(4);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM r WHERE i=1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM r WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM r WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM s WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM s WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM s WHERE i=4;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM t WHERE j=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM t WHERE j=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DROP MATERIALIZED VIEW mv;
+DROP VIEW v;
+
+-- 3-ways outer join (left & right)
+CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r LEFT JOIN s ON r.i=s.i RIGHT JOIN t ON s.j=t.j;
+CREATE VIEW v(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r LEFT JOIN s ON r.i=s.i RIGHT JOIN t ON s.j=t.j;
+SAVEPOINT p1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+
+INSERT INTO r VALUES (1),(2),(3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+INSERT INTO r VALUES (4),(5);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+INSERT INTO s VALUES (1,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+INSERT INTO s VALUES (2,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+INSERT INTO t VALUES (1),(2);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+INSERT INTO t VALUES (3),(4);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM r WHERE i=1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM r WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM r WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM s WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM s WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM s WHERE i=4;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM t WHERE j=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM t WHERE j=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DROP MATERIALIZED VIEW mv;
+DROP VIEW v;
+
+-- 3-ways outer join (left & inner)
+CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r LEFT JOIN s ON r.i=s.i INNER JOIN t ON s.j=t.j;
+CREATE VIEW v(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r LEFT JOIN s ON r.i=s.i INNER JOIN t ON s.j=t.j;
+SAVEPOINT p1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+
+INSERT INTO r VALUES (1),(2),(3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+INSERT INTO r VALUES (4),(5);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+INSERT INTO s VALUES (1,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+INSERT INTO s VALUES (2,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+INSERT INTO t VALUES (1),(2);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+INSERT INTO t VALUES (3),(4);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM r WHERE i=1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM r WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM r WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM s WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM s WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM s WHERE i=4;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM t WHERE j=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM t WHERE j=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DROP MATERIALIZED VIEW mv;
+DROP VIEW v;
+
+-- 3-ways outer join (right & full)
+CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r RIGHT JOIN s ON r.i=s.i FULL JOIN t ON s.j=t.j;
+CREATE VIEW v(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r RIGHT JOIN s ON r.i=s.i FULL JOIN t ON s.j=t.j;
+SAVEPOINT p1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+
+INSERT INTO r VALUES (1),(2),(3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+INSERT INTO r VALUES (4),(5);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+INSERT INTO s VALUES (1,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+INSERT INTO s VALUES (2,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+INSERT INTO t VALUES (1),(2);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+INSERT INTO t VALUES (3),(4);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM r WHERE i=1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM r WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM r WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM s WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM s WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM s WHERE i=4;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM t WHERE j=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM t WHERE j=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DROP MATERIALIZED VIEW mv;
+DROP VIEW v;
+
+-- 3-ways outer join (right & left)
+CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r RIGHT JOIN s ON r.i=s.i LEFT JOIN t ON s.j=t.j;
+CREATE VIEW v(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r RIGHT JOIN s ON r.i=s.i LEFT JOIN t ON s.j=t.j;
+SAVEPOINT p1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+
+INSERT INTO r VALUES (1),(2),(3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+INSERT INTO r VALUES (4),(5);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+INSERT INTO s VALUES (1,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+INSERT INTO s VALUES (2,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+INSERT INTO t VALUES (1),(2);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+INSERT INTO t VALUES (3),(4);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM r WHERE i=1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM r WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM r WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM s WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM s WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM s WHERE i=4;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM t WHERE j=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM t WHERE j=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DROP MATERIALIZED VIEW mv;
+DROP VIEW v;
+
+-- 3-ways outer join (right & right)
+CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r RIGHT JOIN s ON r.i=s.i RIGHT JOIN t ON s.j=t.j;
+CREATE VIEW v(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r RIGHT JOIN s ON r.i=s.i RIGHT JOIN t ON s.j=t.j;
+SAVEPOINT p1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+
+INSERT INTO r VALUES (1),(2),(3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+INSERT INTO r VALUES (4),(5);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+INSERT INTO s VALUES (1,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+INSERT INTO s VALUES (2,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+INSERT INTO t VALUES (1),(2);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+INSERT INTO t VALUES (3),(4);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM r WHERE i=1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM r WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM r WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM s WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM s WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM s WHERE i=4;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM t WHERE j=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM t WHERE j=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DROP MATERIALIZED VIEW mv;
+DROP VIEW v;
+
+-- 3-ways outer join (inner & FULL)
+CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r INNER JOIN s ON r.i=s.i FULL JOIN t ON s.j=t.j;
+CREATE VIEW v(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r INNER JOIN s ON r.i=s.i FULL JOIN t ON s.j=t.j;
+SAVEPOINT p1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+
+INSERT INTO r VALUES (1),(2),(3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+INSERT INTO r VALUES (4),(5);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+INSERT INTO s VALUES (1,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+INSERT INTO s VALUES (2,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+INSERT INTO t VALUES (1),(2);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+INSERT INTO t VALUES (3),(4);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM r WHERE i=1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM r WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM r WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM s WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM s WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM s WHERE i=4;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM t WHERE j=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM t WHERE j=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DROP MATERIALIZED VIEW mv;
+DROP VIEW v;
+
+-- 3-ways outer join (inner & left)
+CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r INNER JOIN s ON r.i=s.i LEFT JOIN t ON s.j=t.j;
+CREATE VIEW v(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r INNER JOIN s ON r.i=s.i LEFT JOIN t ON s.j=t.j;
+SAVEPOINT p1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+
+INSERT INTO r VALUES (1),(2),(3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+INSERT INTO r VALUES (4),(5);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+INSERT INTO s VALUES (1,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+INSERT INTO s VALUES (2,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+INSERT INTO t VALUES (1),(2);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+INSERT INTO t VALUES (3),(4);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM r WHERE i=1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM r WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM r WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM s WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM s WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM s WHERE i=4;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM t WHERE j=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM t WHERE j=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DROP MATERIALIZED VIEW mv;
+DROP VIEW v;
+
+-- 3-ways outer join (inner & right)
+CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r INNER JOIN s ON r.i=s.i RIGHT JOIN t ON s.j=t.j;
+CREATE VIEW v(r, si, sj, t) AS
+ SELECT r.i, s.i, s.j, t.j
+   FROM r INNER JOIN s ON r.i=s.i RIGHT JOIN t ON s.j=t.j;
+SAVEPOINT p1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+
+INSERT INTO r VALUES (1),(2),(3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+INSERT INTO r VALUES (4),(5);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+INSERT INTO s VALUES (1,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+INSERT INTO s VALUES (2,3);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+INSERT INTO t VALUES (1),(2);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+INSERT INTO t VALUES (3),(4);
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM r WHERE i=1;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM r WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM r WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM s WHERE i=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM s WHERE i=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM s WHERE i=4;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM t WHERE j=2;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+DELETE FROM t WHERE j=3;
+SELECT * FROM mv ORDER BY r, si, sj, t;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DROP MATERIALIZED VIEW mv;
+DROP VIEW v;
+
+-- outer join with WHERE clause
+CREATE INCREMENTAL MATERIALIZED VIEW mv(r, s) AS
+ SELECT r.i, s.i
+   FROM r FULL JOIN s ON r.i=s.i WHERE s.i > 0;
+CREATE VIEW v(r, s) AS
+ SELECT r.i, s.i
+   FROM r FULL JOIN s ON r.i=s.i WHERE s.i > 0;
+SAVEPOINT p1;
+SELECT * FROM mv ORDER BY r, s;
+
+INSERT INTO r VALUES (1),(2),(3);
+SELECT * FROM mv ORDER BY r, s;
+SELECT is_match();
+INSERT INTO r VALUES (4),(5);
+SELECT * FROM mv ORDER BY r, s;
+SELECT is_match();
+ROLLBACK TO p1;
+
+INSERT INTO s VALUES (1,3);
+SELECT * FROM mv ORDER BY r, s;
+SELECT is_match();
+INSERT INTO s VALUES (2,3);
+SELECT * FROM mv ORDER BY r, s;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM r WHERE i=1;
+SELECT * FROM mv ORDER BY r, s;
+SELECT is_match();
+DELETE FROM r WHERE i=2;
+SELECT * FROM mv ORDER BY r, s;
+SELECT is_match();
+DELETE FROM r WHERE i=3;
+SELECT * FROM mv ORDER BY r, s;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM s WHERE i=2;
+SELECT * FROM mv ORDER BY r, s;
+SELECT is_match();
+DELETE FROM s WHERE i=3;
+SELECT * FROM mv ORDER BY r, s;
+SELECT is_match();
+DELETE FROM s WHERE i=4;
+SELECT * FROM mv ORDER BY r, s;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DROP MATERIALIZED VIEW mv;
+DROP VIEW v;
+
+-- self outer join
+CREATE INCREMENTAL MATERIALIZED VIEW mv(r1, r2) AS
+ SELECT r.i, r2.i
+   FROM r FULL JOIN r as r2 ON r.i=r2.i;
+CREATE VIEW v(r1, r2) AS
+ SELECT r.i, r2.i
+   FROM r FULL JOIN r as r2 ON r.i=r2.i;
+SAVEPOINT p1;
+SELECT * FROM mv ORDER BY r1, r2;
+
+INSERT INTO r VALUES (1),(2),(3);
+SELECT * FROM mv ORDER BY r1, r2;
+SELECT is_match();
+INSERT INTO r VALUES (4),(5);
+SELECT * FROM mv ORDER BY r1, r2;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DELETE FROM r WHERE i=1;
+SELECT * FROM mv ORDER BY r1, r2;
+SELECT is_match();
+DELETE FROM r WHERE i=2;
+SELECT * FROM mv ORDER BY r1, r2;
+SELECT is_match();
+DELETE FROM r WHERE i=3;
+SELECT * FROM mv ORDER BY r1, r2;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DROP MATERIALIZED VIEW mv;
+DROP VIEW v;
+
+-- support simultaneous table changes on outer join
+CREATE INCREMENTAL MATERIALIZED VIEW mv(r, s) AS
+ SELECT r.i, s.i
+   FROM r FULL JOIN s ON r.i=s.i;
+CREATE VIEW v(r, s) AS
+ SELECT r.i, s.i
+   FROM r FULL JOIN s ON r.i=s.i;
+SAVEPOINT p1;
+SELECT * FROM mv ORDER BY r, s;
+
+WITH
+ ri AS (INSERT INTO r VALUES (1),(2),(3) RETURNING 0),
+ si AS (INSERT INTO s VALUES (1,3) RETURNING 0)
+SELECT;
+SELECT * FROM mv ORDER BY r, s;
+SELECT is_match();
+ROLLBACK TO p1;
+
+WITH
+ rd AS (DELETE FROM r WHERE i=1 RETURNING 0),
+ sd AS (DELETE FROM s WHERE i=2 RETURNING 0)
+SELECT;
+SELECT * FROM mv ORDER BY r, s;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DROP MATERIALIZED VIEW mv;
+DROP VIEW v;
+
+-- multiple change of the same table on outer join
+CREATE INCREMENTAL MATERIALIZED VIEW mv(r, s) AS
+ SELECT r.i, s.i
+   FROM r FULL JOIN s ON r.i=s.i;
+CREATE VIEW v(r, s) AS
+ SELECT r.i, s.i
+   FROM r FULL JOIN s ON r.i=s.i;
+SAVEPOINT p1;
+SELECT * FROM mv ORDER BY r, s;
+
+WITH
+ ri1 AS (INSERT INTO r VALUES (1),(2),(3) RETURNING 0),
+ ri2 AS (INSERT INTO r VALUES (4),(5) RETURNING 0),
+ rd AS (DELETE FROM r WHERE i IN (3,4) RETURNING 0)
+SELECT;
+SELECT * FROM mv ORDER BY r, s;
+SELECT is_match();
+ROLLBACK TO p1;
+
+DROP MATERIALIZED VIEW mv;
+DROP VIEW v;
+
+ROLLBACK;
+
+-- outer join view's targetlist must contain vars in the join conditions
+CREATE INCREMENTAL MATERIALIZED VIEW mv AS SELECT a.i FROM mv_base_a a LEFT JOIN mv_base_b b ON a.i=b.i;
+CREATE INCREMENTAL MATERIALIZED VIEW mv AS SELECT a.i,j,k FROM mv_base_a a LEFT JOIN mv_base_b b USING(i);
+
+-- outer join view's targetlist cannot contain non strict functions
+CREATE INCREMENTAL MATERIALIZED VIEW mv AS SELECT a.i, b.i, (k > 10 OR k = -1) FROM mv_base_a a LEFT JOIN mv_base_b b ON a.i=b.i;
+CREATE INCREMENTAL MATERIALIZED VIEW mv AS SELECT a.i, b.i, CASE WHEN k>0 THEN 1 ELSE 0 END FROM mv_base_a a LEFT JOIN mv_base_b b ON a.i=b.i;
+
+-- outer join supports only simple equijoin
+CREATE INCREMENTAL MATERIALIZED VIEW mv(a,b) AS SELECT a.i, b.i FROM mv_base_a a LEFT JOIN mv_base_b b ON a.i>b.i;
+CREATE INCREMENTAL MATERIALIZED VIEW mv(a,b,k,j) AS SELECT a.i, b.i, k j FROM mv_base_a a LEFT JOIN mv_base_b b ON a.i=b.i AND k=j;
+
+-- outer join view's WHERE clause cannot contain non null-rejecting predicates
+CREATE INCREMENTAL MATERIALIZED VIEW mv(a,b) AS SELECT a.i, b.i FROM mv_base_a a LEFT JOIN mv_base_b b ON a.i=b.i WHERE k IS NULL;
+CREATE INCREMENTAL MATERIALIZED VIEW mv(a,b) AS SELECT a.i, b.i FROM mv_base_a a LEFT JOIN mv_base_b b ON a.i=b.i WHERE (k > 10 OR k = -1);
+
+-- aggregate is not supported with outer join
+CREATE INCREMENTAL MATERIALIZED VIEW mv(a,b,v) AS SELECT a.i, b.i, sum(k) FROM mv_base_a a LEFT JOIN mv_base_b b ON a.i=b.i GROUP BY a.i, b.i;
+
+-- subquery is not supported with outer join
+CREATE INCREMENTAL MATERIALIZED VIEW mv(a,b) AS SELECT a.i, b.i FROM mv_base_a a LEFT JOIN (SELECT * FROM mv_base_b) b ON a.i=b.i;
+CREATE INCREMENTAL MATERIALIZED VIEW mv(a,b) AS SELECT a.i, b.i FROM mv_base_a a LEFT JOIN mv_base_b b ON a.i=b.i WHERE EXISTS (SELECT 1 FROM mv_base_b b2 WHERE a.j = b.k);
+
 -- contain system column
 CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm01 AS SELECT i,j,xmin FROM mv_base_a;
 CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm02 AS SELECT i,j FROM mv_base_a WHERE xmin = '610';

--- a/src/test/regress/sql/incremental_matview.sql
+++ b/src/test/regress/sql/incremental_matview.sql
@@ -236,7 +236,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
--- 3-ways outer join (full & full)
+-- 3-way outer join (full & full)
 CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
  SELECT r.i, s.i, s.j, t.j
    FROM r FULL JOIN s ON r.i=s.i FULL JOIN t ON s.j=t.j;
@@ -303,7 +303,7 @@ ROLLBACK TO p1;
 DROP MATERIALIZED VIEW mv;
 DROP VIEW v;
 
--- 3-ways outer join (full & left)
+-- 3-way outer join (full & left)
 CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
  SELECT r.i, s.i, s.j, t.j
    FROM r FULL JOIN s ON r.i=s.i LEFT JOIN t ON s.j=t.j;
@@ -370,7 +370,7 @@ ROLLBACK TO p1;
 DROP MATERIALIZED VIEW mv;
 DROP VIEW v;
 
--- 3-ways outer join (full & right)
+-- 3-way outer join (full & right)
 CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
  SELECT r.i, s.i, s.j, t.j
    FROM r FULL JOIN s ON r.i=s.i RIGHT JOIN t ON s.j=t.j;
@@ -437,7 +437,7 @@ ROLLBACK TO p1;
 DROP MATERIALIZED VIEW mv;
 DROP VIEW v;
 
--- 3-ways outer join (full & inner)
+-- 3-way outer join (full & inner)
 CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
  SELECT r.i, s.i, s.j, t.j
    FROM r FULL JOIN s ON r.i=s.i INNER JOIN t ON s.j=t.j;
@@ -504,7 +504,7 @@ ROLLBACK TO p1;
 DROP MATERIALIZED VIEW mv;
 DROP VIEW v;
 
--- 3-ways outer join (left & full)
+-- 3-way outer join (left & full)
 CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
  SELECT r.i, s.i, s.j, t.j
    FROM r LEFT JOIN s ON r.i=s.i FULL JOIN t ON s.j=t.j;
@@ -571,7 +571,7 @@ ROLLBACK TO p1;
 DROP MATERIALIZED VIEW mv;
 DROP VIEW v;
 
--- 3-ways outer join (left & left)
+-- 3-way outer join (left & left)
 CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
  SELECT r.i, s.i, s.j, t.j
    FROM r LEFT JOIN s ON r.i=s.i LEFT JOIN t ON s.j=t.j;
@@ -638,7 +638,7 @@ ROLLBACK TO p1;
 DROP MATERIALIZED VIEW mv;
 DROP VIEW v;
 
--- 3-ways outer join (left & right)
+-- 3-way outer join (left & right)
 CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
  SELECT r.i, s.i, s.j, t.j
    FROM r LEFT JOIN s ON r.i=s.i RIGHT JOIN t ON s.j=t.j;
@@ -705,7 +705,7 @@ ROLLBACK TO p1;
 DROP MATERIALIZED VIEW mv;
 DROP VIEW v;
 
--- 3-ways outer join (left & inner)
+-- 3-way outer join (left & inner)
 CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
  SELECT r.i, s.i, s.j, t.j
    FROM r LEFT JOIN s ON r.i=s.i INNER JOIN t ON s.j=t.j;
@@ -772,7 +772,7 @@ ROLLBACK TO p1;
 DROP MATERIALIZED VIEW mv;
 DROP VIEW v;
 
--- 3-ways outer join (right & full)
+-- 3-way outer join (right & full)
 CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
  SELECT r.i, s.i, s.j, t.j
    FROM r RIGHT JOIN s ON r.i=s.i FULL JOIN t ON s.j=t.j;
@@ -839,7 +839,7 @@ ROLLBACK TO p1;
 DROP MATERIALIZED VIEW mv;
 DROP VIEW v;
 
--- 3-ways outer join (right & left)
+-- 3-way outer join (right & left)
 CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
  SELECT r.i, s.i, s.j, t.j
    FROM r RIGHT JOIN s ON r.i=s.i LEFT JOIN t ON s.j=t.j;
@@ -906,7 +906,7 @@ ROLLBACK TO p1;
 DROP MATERIALIZED VIEW mv;
 DROP VIEW v;
 
--- 3-ways outer join (right & right)
+-- 3-way outer join (right & right)
 CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
  SELECT r.i, s.i, s.j, t.j
    FROM r RIGHT JOIN s ON r.i=s.i RIGHT JOIN t ON s.j=t.j;
@@ -973,7 +973,7 @@ ROLLBACK TO p1;
 DROP MATERIALIZED VIEW mv;
 DROP VIEW v;
 
--- 3-ways outer join (inner & FULL)
+-- 3-way outer join (inner & FULL)
 CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
  SELECT r.i, s.i, s.j, t.j
    FROM r INNER JOIN s ON r.i=s.i FULL JOIN t ON s.j=t.j;
@@ -1040,7 +1040,7 @@ ROLLBACK TO p1;
 DROP MATERIALIZED VIEW mv;
 DROP VIEW v;
 
--- 3-ways outer join (inner & left)
+-- 3-way outer join (inner & left)
 CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
  SELECT r.i, s.i, s.j, t.j
    FROM r INNER JOIN s ON r.i=s.i LEFT JOIN t ON s.j=t.j;
@@ -1107,7 +1107,7 @@ ROLLBACK TO p1;
 DROP MATERIALIZED VIEW mv;
 DROP VIEW v;
 
--- 3-ways outer join (inner & right)
+-- 3-way outer join (inner & right)
 CREATE INCREMENTAL MATERIALIZED VIEW mv(r, si, sj, t) AS
  SELECT r.i, s.i, s.j, t.j
    FROM r INNER JOIN s ON r.i=s.i RIGHT JOIN t ON s.j=t.j;


### PR DESCRIPTION
In case of outer-joins, additionally to deltas which occur in inner-join
case we need additional delete or insert of dangling tuples, that is,
null-extended tuples generated when join-condition doesn't match.

This implementation basically based on the algorithm of Larson & Zhou
(2007) [1]. Before view maintenances, jointree is analysed and "view
maintenance graph" is generated, which represents which tuples in the
views are affected when a table is modified. Tuples on which the modified
table is not null-extended are directly affected by this change. Such
affects are calculated similarly to inner-joins. On the other hand,
dangling tuples generated by joining (directly) affected tuples can be
indirectly affected. This means that we may need to delete dangling
tuples when any tuples are inserted to a table, as well as to insert
dangling tuples when tuples are deleted from a table.

[1] Efficient Maintenance of Materialized Outer-Join Views (Larson & Zhou, 2007)
https://ieeexplore.ieee.org/document/4221654

Currently, we have following restrictions:

- outer join view's targetlist must contain attributes used in join conditions
- outer join view's targetlist cannot contain non-strict functions
- outer join supports only simple equijoin
- outer join view's WHERE clause cannot contain non null-rejecting predicates
- aggregate is not supported with outer join
- subquery is not supported with outer join

Github issue #7

We also support view including NULL (Github issue #31) since outer joins
generate dangling tuples including NULL and IVM have to be able to handle
these correctly.