### PR TITLE
Fix mistake of tab-compleate on psql

### DIFF
--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -1001,7 +1001,7 @@ static const pgsql_thing_t words_after_create[] = {
 	{"FOREIGN TABLE", NULL, NULL, NULL},
 	{"FUNCTION", NULL, NULL, Query_for_list_of_functions},
 	{"GROUP", Query_for_list_of_roles},
-	{"INCREMENTAL MATERIALIZED VIEW", NULL, NULL, &Query_for_list_of_matviews},
+	{"INCREMENTAL MATERIALIZED VIEW", NULL, NULL, &Query_for_list_of_matviews, THING_NO_DROP | THING_NO_ALTER},
 	{"INDEX", NULL, NULL, &Query_for_list_of_indexes},
 	{"LANGUAGE", Query_for_list_of_languages},
 	{"LARGE OBJECT", NULL, NULL, NULL, THING_NO_CREATE | THING_NO_DROP},


### PR DESCRIPTION
'INCREMENTAL' phrase was appeared next candiate for DROP and ALTER statement in psql.
Actually, It use CREATE statement only.

This fix is by the followiing nuko-san's review:
https://www.postgresql.org/message-id/CAF3Gu1ZZrbMDOC91Rqxet9%3DwvPnSP11MOYuF0-XpcFJ8c4UYYA%40mail.gmail.com