### PR TITLE
Fix a bug occurs when a sub-transaction is aborted.

### DIFF
--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -4903,6 +4903,9 @@ AbortSubTransaction(void)
 	AbortBufferIO();
 	UnlockBuffers();
 
+	/* Clean up hash entries for incremental view maintenance */
+	AtAbort_IVM();
+
 	/* Reset WAL record construction state */
 	XLogResetInsertion();
 


### PR DESCRIPTION
When a sub-transaction was aborted, internal information in the memory
were not cleaned up. This includes trigger counter value which is used
to determine to start the view maintenance. Therefore, this issue caused
a bug that views are not updated even when base tables are modified.

Github issue #45