### PR TITLE
Check if aggregate functions cat be used in IVM using OID

### DIFF
--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -65,6 +65,7 @@
 #include "utils/syscache.h"
 
 #include "optimizer/clauses.h"
+#include "utils/fmgroids.h"
 
 typedef struct
 {
@@ -100,6 +101,7 @@ static void CreateIvmTrigger(Oid relOid, Oid viewOid, char *matviewname, int16 t
 static void CreateIvmTriggersOnBaseTables(Query *qry, Node *jtnode, Oid matviewOid, char* matviewname, Relids *relids);
 static void check_ivm_restriction_walker(Node *node, check_ivm_restriction_context *ctx, int depth);
 static bool is_equijoin_condition(OpExpr *op);
+static void check_aggregate_supports_ivm(Oid aggfnoid);
 
 /*
  * create_ctas_internal
@@ -441,18 +443,8 @@ ExecCreateTableAs(CreateTableAsStmt *stmt, const char *queryString,
 						Aggref *aggref = (Aggref *) tle->expr;
 						const char *aggname = get_func_name(aggref->aggfnoid);
 
-						/* XXX: need some generalization
-						 *
-						 * Specifically, Using func names is not robust.  We can use oids instead
-						 * of names, but it would be nice to add some information to pg_aggregate.
-						 */
-						if (strcmp(aggname, "sum") !=0
-							&& strcmp(aggname, "count") != 0
-							&& strcmp(aggname, "avg") != 0
-							&& strcmp(aggname, "min") != 0
-							&& strcmp(aggname, "max") != 0
-						)
-							elog(ERROR, "aggregate function %s is not supported", aggname);
+						/* Check if this supports IVM */
+						check_aggregate_supports_ivm(aggref->aggfnoid);
 
 						/*
 						 * For aggregate functions except to count, add count func with the same arg parameters.
@@ -1274,4 +1266,92 @@ is_equijoin_condition(OpExpr *op)
 		return true;
 
 	return false;
+}
+
+/*
+ * check_aggregate_supports_ivm
+ *
+ * Check if the given aggregate function is supporting
+ */
+static void
+check_aggregate_supports_ivm(Oid aggfnoid)
+{
+	switch (aggfnoid)
+	{
+		/* count */
+		case F_AGG_COUNT_ANY:
+		case F_AGG_COUNT_:
+
+		/* sum */
+		case F_AGG_SUM_INT8:
+		case F_AGG_SUM_INT4:
+		case F_AGG_SUM_INT2:
+		case F_AGG_SUM_FLOAT4:
+		case F_AGG_SUM_FLOAT8:
+		case F_AGG_SUM_MONEY:
+		case F_AGG_SUM_INTERVAL:
+		case F_AGG_SUM_NUMERIC:
+
+		/* avg */
+		case F_AGG_AVG_INT8:
+		case F_AGG_AVG_INT4:
+		case F_AGG_AVG_INT2:
+		case F_AGG_AVG_NUMERIC:
+		case F_AGG_AVG_FLOAT4:
+		case F_AGG_AVG_FLOAT8:
+		case F_AGG_AVG_INTERVAL:
+
+		/* min */
+		case F_AGG_MIN_ANYARRAY:
+		case F_AGG_MIN_INT8:
+		case F_AGG_MIN_INT4:
+		case F_AGG_MIN_INT2:
+		case F_AGG_MIN_OID:
+		case F_AGG_MIN_FLOAT4:
+		case F_AGG_MIN_FLOAT8:
+		case F_AGG_MIN_DATE:
+		case F_AGG_MIN_TIME:
+		case F_AGG_MIN_TIMETZ:
+		case F_AGG_MIN_MONEY:
+		case F_AGG_MIN_TIMESTAMP:
+		case F_AGG_MIN_TIMESTAMPTZ:
+		case F_AGG_MIN_INTERVAL:
+		case F_AGG_MIN_TEXT:
+		case F_AGG_MIN_NUMERIC:
+		case F_AGG_MIN_BPCHAR:
+		case F_AGG_MIN_TID:
+		case F_AGG_MIN_ANYENUM:
+		case F_AGG_MIN_INET:
+		case F_AGG_MIN_PG_LSN:
+
+		/* max */
+		case F_AGG_MAX_ANYARRAY:
+		case F_AGG_MAX_INT8:
+		case F_AGG_MAX_INT4:
+		case F_AGG_MAX_INT2:
+		case F_AGG_MAX_OID:
+		case F_AGG_MAX_FLOAT4:
+		case F_AGG_MAX_FLOAT8:
+		case F_AGG_MAX_DATE:
+		case F_AGG_MAX_TIME:
+		case F_AGG_MAX_TIMETZ:
+		case F_AGG_MAX_MONEY:
+		case F_AGG_MAX_TIMESTAMP:
+		case F_AGG_MAX_TIMESTAMPTZ:
+		case F_AGG_MAX_INTERVAL:
+		case F_AGG_MAX_TEXT:
+		case F_AGG_MAX_NUMERIC:
+		case F_AGG_MAX_BPCHAR:
+		case F_AGG_MAX_TID:
+		case F_AGG_MAX_ANYENUM:
+		case F_AGG_MAX_INET:
+		case F_AGG_MAX_PG_LSN:
+			return;
+
+		default:
+		{
+			const char *aggname = get_func_name(aggfnoid);
+			elog(ERROR, "aggregate function %s is not supported", aggname);
+		}
+	}
 }

--- a/src/backend/utils/Gen_fmgrtab.pl
+++ b/src/backend/utils/Gen_fmgrtab.pl
@@ -79,6 +79,9 @@ foreach my $row (@{ $catalog_data{pg_proc} })
 		retset => $bki_values{proretset},
 		nargs  => $bki_values{pronargs},
 		prosrc => $bki_values{prosrc},
+		prokind => $bki_values{prokind},
+		proname => $bki_values{proname},
+		proargtypes => $bki_values{proargtypes},
 	  };
 }
 
@@ -191,9 +194,18 @@ my %seenit;
 foreach my $s (sort { $a->{oid} <=> $b->{oid} } @fmgr)
 {
 	next if $seenit{ $s->{prosrc} };
-	$seenit{ $s->{prosrc} } = 1;
-	print $ofh "#define F_" . uc $s->{prosrc} . " $s->{oid}\n";
-	print $pfh "extern Datum $s->{prosrc}(PG_FUNCTION_ARGS);\n";
+	print $s->{prokind};
+	if ($s->{prokind} eq "a")
+	{
+		$s->{proargtypes} =~ s/ /_/;
+		print $ofh "#define F_AGG_" . uc $s->{proname} . "_" . uc $s->{proargtypes} . " $s->{oid}\n";
+	}
+	else
+	{
+		$seenit{ $s->{prosrc} } = 1;
+		print $ofh "#define F_" . uc $s->{prosrc} . " $s->{oid}\n";
+		print $pfh "extern Datum $s->{prosrc}(PG_FUNCTION_ARGS);\n";
+	}
 }
 
 # Create the fmgr_builtins table, collect data for fmgr_builtin_oid_index

--- a/src/backend/utils/Gen_fmgrtab.pl
+++ b/src/backend/utils/Gen_fmgrtab.pl
@@ -194,7 +194,6 @@ my %seenit;
 foreach my $s (sort { $a->{oid} <=> $b->{oid} } @fmgr)
 {
 	next if $seenit{ $s->{prosrc} };
-	print $s->{prokind};
 	if ($s->{prokind} eq "a")
 	{
 		$s->{proargtypes} =~ s/ /_/;


### PR DESCRIPTION
Checking it using the aggregate name is not robust because user
defined aggregate might not have the semantics that we assume in
IVM. Gen_fmgrtab.pl is modified so that OID of aggregates are
output to fmgroids.h.