### PR TITLE
Remove temprary tables before user is switched back from matview owner

### DIFF
--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -1570,6 +1570,10 @@ IVM_immediate_maintenance(PG_FUNCTION_ARGS)
 		}
 	}
 
+	/* Clean up hash entry and drop temporary tables */
+	clean_up_IVM_hash_entry(entry);
+	clean_up_IVM_temptable(OIDDelta_old, OIDDelta_new);
+
 	/* Pop the original snapshot. */
 	PopActiveSnapshot();
 
@@ -1580,10 +1584,6 @@ IVM_immediate_maintenance(PG_FUNCTION_ARGS)
 
 	/* Restore userid and security context */
 	SetUserIdAndSecContext(save_userid, save_sec_context);
-
-	/* Clean up hash entry and drop temporary tables */
-	clean_up_IVM_hash_entry(entry);
-	clean_up_IVM_temptable(OIDDelta_old, OIDDelta_new);
 
 	return PointerGetDatum(NULL);
 }


### PR DESCRIPTION
Temporary tables used in IVM are created by the matview owner, but
this was removed by the current owner after the current user was
switched from the matview owner. This caused falure of removing
temprary tables. Fixed by removing temprary tables before user
switching. Github issue #53