### PR TITLE
Support REFRESH MATERIALIZED VIEW command

### DIFF
--- a/doc/src/sgml/catalogs.sgml
+++ b/doc/src/sgml/catalogs.sgml
@@ -3121,6 +3121,18 @@ SCRAM-SHA-256$<replaceable>&lt;iteration count&gt;</replaceable>:<replaceable>&l
       </para>
      </listitem>
     </varlistentry>
+
+    <varlistentry>
+     <term><symbol>DEPENDENCY_IMMV</symbol> (<literal>m</literal>)</term>
+     <listitem>
+      <para>
+       The dependent object was created as part of creation of the Materialized
+       View with Incremental View Maintenance reference, and is really just a 
+       part of its internal implementation. The dependent object must not be
+       dropped unless materialized view dropped.
+      </para>
+     </listitem>
+    </varlistentry>
    </variablelist>
 
    Other dependency flavors might be needed in future.

--- a/src/backend/catalog/dependency.c
+++ b/src/backend/catalog/dependency.c
@@ -588,6 +588,7 @@ findDependentObjects(const ObjectAddress *object,
 			case DEPENDENCY_NORMAL:
 			case DEPENDENCY_AUTO:
 			case DEPENDENCY_AUTO_EXTENSION:
+			case DEPENDENCY_IMMV:
 				/* no problem */
 				break;
 
@@ -914,6 +915,7 @@ findDependentObjects(const ObjectAddress *object,
 				subflags = DEPFLAG_AUTO;
 				break;
 			case DEPENDENCY_INTERNAL:
+			case DEPENDENCY_IMMV:
 				subflags = DEPFLAG_INTERNAL;
 				break;
 			case DEPENDENCY_PARTITION_PRI:

--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -426,16 +426,17 @@ ExecCreateTableAs(CreateTableAsStmt *stmt, const char *queryString,
 			/*
 			 * Mark relisivm field, if it's a matview and into->ivm is true.
 			 */
-			if (is_matview && into->ivm)
-				SetMatViewIVMState(matviewRel, true);
-			copied_query = copyObject(query);
-			AcquireRewriteLocks(copied_query, true, false);
+			SetMatViewIVMState(matviewRel, true);
 
-			CreateIvmTriggersOnBaseTables(copied_query, (Node *)copied_query->jointree, matviewOid, &relids);
+			if (!into->skipData)
+			{
+				copied_query = copyObject(query);
+				AcquireRewriteLocks(copied_query, true, false);
 
+				CreateIvmTriggersOnBaseTables(copied_query, (Node *)copied_query->jointree, matviewOid, &relids);
+				bms_free(relids);
+			}
 			table_close(matviewRel, NoLock);
-
-			bms_free(relids);
 		}
 	}
 

--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -334,8 +334,7 @@ ExecCreateTableAs(CreateTableAsStmt *stmt, const char *queryString,
 			TargetEntry *tle;
 			check_ivm_restriction_context ctx = {false, false, false, NIL};
 			check_ivm_restriction_walker((Node *) copied_query, &ctx, 0);
-			copied_query = rewriteIMMV(copied_query, into->colNames);
-			
+			copied_query = rewriteQueryForIMMV(copied_query, into->colNames);
 			/*
 			 * Add JSONB column for meta information related to outer joins.
 			 * Actually this is required only for delta tables, but we create
@@ -389,8 +388,8 @@ ExecCreateTableAs(CreateTableAsStmt *stmt, const char *queryString,
 			check_ivm_restriction_context ctx = {false, false, false, NIL};
 			check_ivm_restriction_walker((Node *) copied_query, &ctx, 0);
 
-			copied_query = rewriteIMMV(copied_query, into->colNames);
-			
+			copied_query = rewriteQueryForIMMV(copied_query, into->colNames);
+
 			/*
 			 * Add JSONB column for meta information related to outer joins.
 			 * Actually this is required only for delta tables, but we create
@@ -497,10 +496,10 @@ ExecCreateTableAs(CreateTableAsStmt *stmt, const char *queryString,
 }
 
 /*
- * rewriteIMMV -- rewrite query for define query of IMMV
+ * rewriteQueryForIMMV -- rewrite query for definition query of IMMV
  */
 Query *
-rewriteIMMV(Query *query, List *colNames)
+rewriteQueryForIMMV(Query *query, List *colNames)
 {
 	Query *rewritten;
 
@@ -680,7 +679,7 @@ rewriteIMMV(Query *query, List *colNames)
 /*
  * CreateIvmTriggersOnBaseTables -- create IVM triggers on all base tables
  */
-void 
+void
 CreateIvmTriggersOnBaseTables(Query *qry, Node *jtnode, Oid matviewOid, Relids *relids)
 {
 	if (jtnode == NULL)

--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -476,11 +476,15 @@ ExecCreateTableAs(CreateTableAsStmt *stmt, const char *queryString,
 
 		if (into->ivm)
 		{
-
 			Oid matviewOid = address.objectId;
 			Relation matviewRel = table_open(matviewOid, NoLock);
 			Relids	relids = NULL;
 
+			/*
+			 * Mark relisivm field, if it's a matview and into->ivm is true.
+			 */
+			if (is_matview && into->ivm)
+				SetMatViewIVMState(matviewRel, true);
 			copied_query = copyObject(query);
 			AcquireRewriteLocks(copied_query, true, false);
 
@@ -896,11 +900,6 @@ intorel_startup(DestReceiver *self, int operation, TupleDesc typeinfo)
 	if (is_matview && !into->skipData)
 		SetMatViewPopulatedState(intoRelationDesc, true);
 
-	/*
-	 * Mark relisivm field, if it's a matview and into->ivm is true.
-	 */
-	if (is_matview && into->ivm)
-		SetMatViewIVMState(intoRelationDesc, true);
 	/*
 	 * Fill private fields of myState for use by later routines
 	 */

--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -443,7 +443,7 @@ ExecRefreshMatView(RefreshMatViewStmt *stmt, const char *queryString,
 
 	/* If use IMMV, need to rewrite matview query */
 	if (!stmt->skipData && matviewRel->rd_rel->relisivm)
-		dataQuery = rewriteIMMV(dataQuery,NIL);
+		dataQuery = rewriteQueryForIMMV(dataQuery,NIL);
 
 
 
@@ -521,7 +521,7 @@ ExecRefreshMatView(RefreshMatViewStmt *stmt, const char *queryString,
 	}
 
 	/* delete immv triggers */
-	if (matviewRel->rd_rel->relisivm)	
+	if (matviewRel->rd_rel->relisivm)
 	{
 		/* use deleted trigger */
 		Relation	depRel;
@@ -622,14 +622,12 @@ ExecRefreshMatView(RefreshMatViewStmt *stmt, const char *queryString,
 	{
 		Query *copied_query;
 
-		char	*matviewname = quote_qualified_identifier(get_namespace_name(RelationGetNamespace(matviewRel)),
-												 RelationGetRelationName(matviewRel));
 		Relids	relids = NULL;
 		// maybe dataQuery
 		copied_query = copyObject(dataQuery);
 		AcquireRewriteLocks(copied_query, true, false);
 
-		CreateIvmTriggersOnBaseTables(copied_query, (Node *)copied_query->jointree, matviewOid, matviewname, &relids);
+		CreateIvmTriggersOnBaseTables(copied_query, (Node *)copied_query->jointree, matviewOid, &relids);
 
 		bms_free(relids);
 	}

--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -443,7 +443,7 @@ ExecRefreshMatView(RefreshMatViewStmt *stmt, const char *queryString,
 
 	/* If use IMMV, need to rewrite matview query */
 	if (!stmt->skipData && matviewRel->rd_rel->relisivm)
-		dataQuery = rewriteQueryForIMMV(dataQuery,NIL);
+		dataQuery = rewriteQueryForIMMV(dataQuery,NIL, true);
 
 
 

--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -436,6 +436,13 @@ ExecRefreshMatView(RefreshMatViewStmt *stmt, const char *queryString,
 
 
 	dataQuery = get_matview_query(matviewRel);
+	elog_node_display(LOG, "parse tree", dataQuery, Debug_pretty_print);
+
+	/* If use IMMV, need to rewrite matview query */
+	if ( matviewRel->rd_rel->relisivm)
+			dataQuery = rewriteIMMV(dataQuery,NIL);
+
+
 
 	/*
 	 * Check that there is a unique index with no WHERE clause on one or more

--- a/src/include/catalog/dependency.h
+++ b/src/include/catalog/dependency.h
@@ -37,7 +37,8 @@ typedef enum DependencyType
 	DEPENDENCY_PARTITION_SEC = 'S',
 	DEPENDENCY_EXTENSION = 'e',
 	DEPENDENCY_AUTO_EXTENSION = 'x',
-	DEPENDENCY_PIN = 'p'
+	DEPENDENCY_PIN = 'p',
+	DEPENDENCY_IMMV = 'm'
 } DependencyType;
 
 /*

--- a/src/include/commands/createas.h
+++ b/src/include/commands/createas.h
@@ -17,12 +17,15 @@
 #include "catalog/objectaddress.h"
 #include "nodes/params.h"
 #include "nodes/parsenodes.h"
+#include "nodes/pathnodes.h"
 #include "tcop/dest.h"
 #include "utils/queryenvironment.h"
 
 
 extern ObjectAddress ExecCreateTableAs(CreateTableAsStmt *stmt, const char *queryString,
 									   ParamListInfo params, QueryEnvironment *queryEnv, char *completionTag);
+
+extern void CreateIvmTriggersOnBaseTables(Query *qry, Node *jtnode, Oid matviewOid, Relids *relids);
 
 extern Query *rewriteIMMV(Query *query, List *colNames);
 

--- a/src/include/commands/createas.h
+++ b/src/include/commands/createas.h
@@ -27,7 +27,7 @@ extern ObjectAddress ExecCreateTableAs(CreateTableAsStmt *stmt, const char *quer
 
 extern void CreateIvmTriggersOnBaseTables(Query *qry, Node *jtnode, Oid matviewOid, Relids *relids);
 
-extern Query *rewriteQueryForIMMV(Query *query, List *colNames);
+extern Query *rewriteQueryForIMMV(Query *query, List *colNames, bool noerror);
 
 extern int	GetIntoRelEFlags(IntoClause *intoClause);
 

--- a/src/include/commands/createas.h
+++ b/src/include/commands/createas.h
@@ -27,7 +27,7 @@ extern ObjectAddress ExecCreateTableAs(CreateTableAsStmt *stmt, const char *quer
 
 extern void CreateIvmTriggersOnBaseTables(Query *qry, Node *jtnode, Oid matviewOid, Relids *relids);
 
-extern Query *rewriteIMMV(Query *query, List *colNames);
+extern Query *rewriteQueryForIMMV(Query *query, List *colNames);
 
 extern int	GetIntoRelEFlags(IntoClause *intoClause);
 

--- a/src/include/commands/createas.h
+++ b/src/include/commands/createas.h
@@ -24,6 +24,8 @@
 extern ObjectAddress ExecCreateTableAs(CreateTableAsStmt *stmt, const char *queryString,
 									   ParamListInfo params, QueryEnvironment *queryEnv, char *completionTag);
 
+extern Query *rewriteIMMV(Query *query, List *colNames);
+
 extern int	GetIntoRelEFlags(IntoClause *intoClause);
 
 extern DestReceiver *CreateIntoRelDestReceiver(IntoClause *intoClause);

--- a/src/test/regress/expected/incremental_matview.out
+++ b/src/test/regress/expected/incremental_matview.out
@@ -12,7 +12,11 @@ INSERT INTO mv_base_b VALUES
   (2,102),
   (3,103),
   (4,104);
-CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_1 AS SELECT i,j,k FROM mv_base_a a INNER JOIN mv_base_b b USING(i);
+CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_1 AS SELECT i,j,k FROM mv_base_a a INNER JOIN mv_base_b b USING(i) WITH NO DATA;
+SELECT * FROM mv_ivm_1 ORDER BY 1,2,3;
+ERROR:  materialized view "mv_ivm_1" has not been populated
+HINT:  Use the REFRESH MATERIALIZED VIEW command.
+REFRESH MATERIALIZED VIEW mv_ivm_1;
 SELECT * FROM mv_ivm_1 ORDER BY 1,2,3;
  i | j  |  k  
 ---+----+-----

--- a/src/test/regress/sql/incremental_matview.sql
+++ b/src/test/regress/sql/incremental_matview.sql
@@ -13,8 +13,9 @@ INSERT INTO mv_base_b VALUES
   (3,103),
   (4,104);
 
-CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_1 AS SELECT i,j,k FROM mv_base_a a INNER JOIN mv_base_b b USING(i);
-
+CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_1 AS SELECT i,j,k FROM mv_base_a a INNER JOIN mv_base_b b USING(i) WITH NO DATA;
+SELECT * FROM mv_ivm_1 ORDER BY 1,2,3;
+REFRESH MATERIALIZED VIEW mv_ivm_1;
 SELECT * FROM mv_ivm_1 ORDER BY 1,2,3;
 -- immediaite maintenance
 BEGIN;


### PR DESCRIPTION
REFRESH MATERIALIZED VIEW command and CREATE INCREMENTAL MATERIALIZED VIEW .... WITH NO DATA  are supported by this pull request.

IF spcify WITH NO DATA option, IMMV don't create immv-triggers. and recreate immv-triggers when REFRESH command execute.

Add new type 'm' in deptye column of pg_depend. it is used by REFRESH immv's triggers.

For example:

test=# CREATE INCREMENTAL MATERIALIZED VIEW immv AS SELECT * FROM base_a INNER JOIN base_b USING(i);
SELECT 2
test=# SELECT * FROM pg_depend WHERE refobjid = 'immv'::regclass;
 classid | objid | objsubid | refclassid | refobjid | refobjsubid | deptype 
---------+-------+----------+------------+----------+-------------+---------
    1247 | 16837 |        0 |       1259 |    16835 |           0 | i
    2618 | 16838 |        0 |       1259 |    16835 |           0 | i
    2618 | 16838 |        0 |       1259 |    16835 |           0 | n
    2620 | 16839 |        0 |       1259 |    16835 |           0 | m
    2620 | 16840 |        0 |       1259 |    16835 |           0 | m
    2620 | 16841 |        0 |       1259 |    16835 |           0 | m
    2620 | 16842 |        0 |       1259 |    16835 |           0 | m
    2620 | 16843 |        0 |       1259 |    16835 |           0 | m
    2620 | 16844 |        0 |       1259 |    16835 |           0 | m
    2620 | 16845 |        0 |       1259 |    16835 |           0 | m
    2620 | 16846 |        0 |       1259 |    16835 |           0 | m
    2620 | 16847 |        0 |       1259 |    16835 |           0 | m
    2620 | 16848 |        0 |       1259 |    16835 |           0 | m
    2620 | 16849 |        0 |       1259 |    16835 |           0 | m
    2620 | 16850 |        0 |       1259 |    16835 |           0 | m
(15 rows)

test=# REFRESH MATERIALIZED VIEW immv;
REFRESH MATERIALIZED VIEW
test=# SELECT * FROM pg_depend WHERE refobjid = 'immv'::regclass;
 classid | objid | objsubid | refclassid | refobjid | refobjsubid | deptype 
---------+-------+----------+------------+----------+-------------+---------
    1247 | 16837 |        0 |       1259 |    16835 |           0 | i
    2618 | 16838 |        0 |       1259 |    16835 |           0 | i
    2618 | 16838 |        0 |       1259 |    16835 |           0 | n
    2620 | 16854 |        0 |       1259 |    16835 |           0 | m
    2620 | 16855 |        0 |       1259 |    16835 |           0 | m
    2620 | 16856 |        0 |       1259 |    16835 |           0 | m
    2620 | 16857 |        0 |       1259 |    16835 |           0 | m
    2620 | 16858 |        0 |       1259 |    16835 |           0 | m
    2620 | 16859 |        0 |       1259 |    16835 |           0 | m
    2620 | 16860 |        0 |       1259 |    16835 |           0 | m
    2620 | 16861 |        0 |       1259 |    16835 |           0 | m
    2620 | 16862 |        0 |       1259 |    16835 |           0 | m
    2620 | 16863 |        0 |       1259 |    16835 |           0 | m
    2620 | 16864 |        0 |       1259 |    16835 |           0 | m
    2620 | 16865 |        0 |       1259 |    16835 |           0 | m
(15 rows)

test=# REFRESH MATERIALIZED VIEW immv  WITH NO DATA;
REFRESH MATERIALIZED VIEW
test=# SELECT * FROM pg_depend WHERE refobjid = 'immv'::regclass;
 classid | objid | objsubid | refclassid | refobjid | refobjsubid | deptype 
---------+-------+----------+------------+----------+-------------+---------
    1247 | 16837 |        0 |       1259 |    16835 |           0 | i
    2618 | 16838 |        0 |       1259 |    16835 |           0 | i
    2618 | 16838 |        0 |       1259 |    16835 |           0 | n
(3 rows)

test=# SELECT * FROM immv;
ERROR:  materialized view "immv" has not been populated
HINT:  Use the REFRESH MATERIALIZED VIEW command.
