### PR TITLE
Support REFRESH MATERIALIZED VIEW command

### DIFF
--- a/doc/src/sgml/catalogs.sgml
+++ b/doc/src/sgml/catalogs.sgml
@@ -3121,6 +3121,18 @@ SCRAM-SHA-256$<replaceable>&lt;iteration count&gt;</replaceable>:<replaceable>&l
       </para>
      </listitem>
     </varlistentry>
+
+    <varlistentry>
+     <term><symbol>DEPENDENCY_IMMV</symbol> (<literal>m</literal>)</term>
+     <listitem>
+      <para>
+       The dependent object was created as part of creation of the Materialized
+       View with Incremental View Maintenance reference, and is really just a 
+       part of its internal implementation. The dependent object must not be
+       dropped unless materialized view dropped.
+      </para>
+     </listitem>
+    </varlistentry>
    </variablelist>
 
    Other dependency flavors might be needed in future.

--- a/src/backend/catalog/dependency.c
+++ b/src/backend/catalog/dependency.c
@@ -588,6 +588,7 @@ findDependentObjects(const ObjectAddress *object,
 			case DEPENDENCY_NORMAL:
 			case DEPENDENCY_AUTO:
 			case DEPENDENCY_AUTO_EXTENSION:
+			case DEPENDENCY_IMMV:
 				/* no problem */
 				break;
 
@@ -914,6 +915,7 @@ findDependentObjects(const ObjectAddress *object,
 				subflags = DEPFLAG_AUTO;
 				break;
 			case DEPENDENCY_INTERNAL:
+			case DEPENDENCY_IMMV:
 				subflags = DEPFLAG_INTERNAL;
 				break;
 			case DEPENDENCY_PARTITION_PRI:

--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -328,6 +328,10 @@ ExecCreateTableAs(CreateTableAsStmt *stmt, const char *queryString,
 	if (is_matview && into->ivm)
 	{
 		check_ivm_restriction_context ctx = {false, false, false, NIL};
+
+		if(contain_mutable_functions((Node *)query))
+			ereport(ERROR, (errmsg("functions in IMMV must be marked IMMUTABLE")));
+
 		check_ivm_restriction_walker((Node *) query, &ctx, 0);
 		query = rewriteQueryForIMMV(query, into->colNames);
 	}

--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -1001,7 +1001,7 @@ CreateIvmTrigger(Oid relOid, Oid viewOid, int16 type, int16 timing)
 	address = CreateTrigger(ivm_trigger, NULL, relOid, InvalidOid, InvalidOid,
 						 InvalidOid, InvalidOid, InvalidOid, NULL, true, false);
 
-	recordDependencyOn(&address, &refaddr, DEPENDENCY_AUTO);
+	recordDependencyOn(&address, &refaddr, DEPENDENCY_IMMV);
 
 	/* Make changes-so-far visible */
 	CommandCounterIncrement();

--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -65,6 +65,9 @@
 #include "parser/parse_coerce.h"
 #include "catalog/pg_collation_d.h"
 #include "parser/parse_collate.h"
+#include "catalog/pg_depend.h"
+#include "catalog/pg_trigger.h"
+#include "utils/fmgroids.h"
 
 
 typedef struct
@@ -436,6 +439,13 @@ ExecRefreshMatView(RefreshMatViewStmt *stmt, const char *queryString,
 
 
 	dataQuery = get_matview_query(matviewRel);
+	elog_node_display(LOG, "parse tree", dataQuery, Debug_pretty_print);
+
+	/* If use IMMV, need to rewrite matview query */
+	if (!stmt->skipData && matviewRel->rd_rel->relisivm)
+		dataQuery = rewriteQueryForIMMV(dataQuery,NIL, true);
+
+
 
 	/*
 	 * Check that there is a unique index with no WHERE clause on one or more
@@ -510,6 +520,52 @@ ExecRefreshMatView(RefreshMatViewStmt *stmt, const char *queryString,
 		relpersistence = matviewRel->rd_rel->relpersistence;
 	}
 
+	/* delete immv triggers */
+	if (matviewRel->rd_rel->relisivm)
+	{
+		/* use deleted trigger */
+		Relation	depRel;
+		ScanKeyData key;
+		SysScanDesc scan;
+		HeapTuple	tup;
+		ObjectAddresses *immv_triggers;
+
+		immv_triggers = new_object_addresses();
+
+		/*
+		 * We save some cycles by opening pg_depend just once and passing the
+		 * Relation pointer down to all the recursive deletion steps.
+		 */
+		depRel = table_open(DependRelationId, RowExclusiveLock);
+
+		ScanKeyInit(&key,
+					Anum_pg_depend_refobjid,
+					BTEqualStrategyNumber, F_OIDEQ,
+					ObjectIdGetDatum(matviewOid));
+
+		scan = systable_beginscan(depRel, DependReferenceIndexId, true,
+								  NULL, 1, &key);
+		while ((tup = systable_getnext(scan)) != NULL)
+		{
+			ObjectAddress obj;
+			Form_pg_depend foundDep = (Form_pg_depend) GETSTRUCT(tup);
+
+			if (foundDep->deptype == DEPENDENCY_IMMV)
+			{
+				obj.classId = foundDep->classid;
+				obj.objectId = foundDep->objid;
+				obj.objectSubId = foundDep->refobjsubid;
+				add_exact_object_address(&obj, immv_triggers);
+			}
+		}
+		systable_endscan(scan);
+
+		performMultipleDeletions(immv_triggers, DROP_RESTRICT, PERFORM_DELETION_INTERNAL);
+
+		table_close(depRel, RowExclusiveLock);
+		free_object_addresses(immv_triggers);
+	}
+
 	/*
 	 * Create the transient table that will receive the regenerated data. Lock
 	 * it against access by any other process until commit (by which time it
@@ -562,6 +618,20 @@ ExecRefreshMatView(RefreshMatViewStmt *stmt, const char *queryString,
 		if (!stmt->skipData)
 			pgstat_count_heap_insert(matviewRel, processed);
 	}
+	if (!stmt->skipData && matviewRel->rd_rel->relisivm)
+	{
+		Query *copied_query;
+
+		Relids	relids = NULL;
+		// maybe dataQuery
+		copied_query = copyObject(dataQuery);
+		AcquireRewriteLocks(copied_query, true, false);
+
+		CreateIvmTriggersOnBaseTables(copied_query, (Node *)copied_query->jointree, matviewOid, &relids);
+
+		bms_free(relids);
+	}
+
 
 	table_close(matviewRel, NoLock);
 

--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -444,7 +444,7 @@ ExecRefreshMatView(RefreshMatViewStmt *stmt, const char *queryString,
 
 	/* If use IMMV, need to rewrite matview query */
 	if (!stmt->skipData && RelationIsIVM(matviewRel))
-		dataQuery = rewriteQueryForIMMV(dataQuery,NIL, true);
+		dataQuery = rewriteQueryForIMMV(dataQuery,NIL);
 
 
 

--- a/src/include/catalog/dependency.h
+++ b/src/include/catalog/dependency.h
@@ -37,7 +37,8 @@ typedef enum DependencyType
 	DEPENDENCY_PARTITION_SEC = 'S',
 	DEPENDENCY_EXTENSION = 'e',
 	DEPENDENCY_AUTO_EXTENSION = 'x',
-	DEPENDENCY_PIN = 'p'
+	DEPENDENCY_PIN = 'p',
+	DEPENDENCY_IMMV = 'm'
 } DependencyType;
 
 /*

--- a/src/include/commands/createas.h
+++ b/src/include/commands/createas.h
@@ -27,7 +27,7 @@ extern ObjectAddress ExecCreateTableAs(CreateTableAsStmt *stmt, const char *quer
 
 extern void CreateIvmTriggersOnBaseTables(Query *qry, Node *jtnode, Oid matviewOid, Relids *relids);
 
-extern Query *rewriteQueryForIMMV(Query *query, List *colNames, bool noerror);
+extern Query *rewriteQueryForIMMV(Query *query, List *colNames);
 
 extern int	GetIntoRelEFlags(IntoClause *intoClause);
 

--- a/src/include/commands/createas.h
+++ b/src/include/commands/createas.h
@@ -17,12 +17,17 @@
 #include "catalog/objectaddress.h"
 #include "nodes/params.h"
 #include "nodes/parsenodes.h"
+#include "nodes/pathnodes.h"
 #include "tcop/dest.h"
 #include "utils/queryenvironment.h"
 
 
 extern ObjectAddress ExecCreateTableAs(CreateTableAsStmt *stmt, const char *queryString,
 									   ParamListInfo params, QueryEnvironment *queryEnv, char *completionTag);
+
+extern void CreateIvmTriggersOnBaseTables(Query *qry, Node *jtnode, Oid matviewOid, Relids *relids);
+
+extern Query *rewriteQueryForIMMV(Query *query, List *colNames, bool noerror);
 
 extern int	GetIntoRelEFlags(IntoClause *intoClause);
 

--- a/src/test/regress/expected/incremental_matview.out
+++ b/src/test/regress/expected/incremental_matview.out
@@ -12,7 +12,11 @@ INSERT INTO mv_base_b VALUES
   (2,102),
   (3,103),
   (4,104);
-CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_1 AS SELECT i,j,k FROM mv_base_a a INNER JOIN mv_base_b b USING(i);
+CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_1 AS SELECT i,j,k FROM mv_base_a a INNER JOIN mv_base_b b USING(i) WITH NO DATA;
+SELECT * FROM mv_ivm_1 ORDER BY 1,2,3;
+ERROR:  materialized view "mv_ivm_1" has not been populated
+HINT:  Use the REFRESH MATERIALIZED VIEW command.
+REFRESH MATERIALIZED VIEW mv_ivm_1;
 SELECT * FROM mv_ivm_1 ORDER BY 1,2,3;
  i | j  |  k  
 ---+----+-----

--- a/src/test/regress/sql/incremental_matview.sql
+++ b/src/test/regress/sql/incremental_matview.sql
@@ -13,8 +13,9 @@ INSERT INTO mv_base_b VALUES
   (3,103),
   (4,104);
 
-CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_1 AS SELECT i,j,k FROM mv_base_a a INNER JOIN mv_base_b b USING(i);
-
+CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_1 AS SELECT i,j,k FROM mv_base_a a INNER JOIN mv_base_b b USING(i) WITH NO DATA;
+SELECT * FROM mv_ivm_1 ORDER BY 1,2,3;
+REFRESH MATERIALIZED VIEW mv_ivm_1;
 SELECT * FROM mv_ivm_1 ORDER BY 1,2,3;
 -- immediaite maintenance
 BEGIN;


### PR DESCRIPTION
This pull request is a summarised  commits of #59 pull request.

REFRESH MATERIALIZED VIEW command and CREATE INCREMENTAL MATERIALIZED VIEW .... WITH NO DATA are supported by this pull request.

IF spcify WITH NO DATA option, IMMV don't create immv-triggers. and recreate immv-triggers when REFRESH command execute.

Add new type 'm' in deptye column of pg_depend. it is used by REFRESH immv's triggers.

For example:

test=# CREATE INCREMENTAL MATERIALIZED VIEW immv AS SELECT * FROM base_a INNER JOIN base_b USING(i);
SELECT 2
test=# SELECT * FROM pg_depend WHERE refobjid = 'immv'::regclass;
classid | objid | objsubid | refclassid | refobjid | refobjsubid | deptype
---------+-------+----------+------------+----------+-------------+---------
1247 | 16837 | 0 | 1259 | 16835 | 0 | i
2618 | 16838 | 0 | 1259 | 16835 | 0 | i
2618 | 16838 | 0 | 1259 | 16835 | 0 | n
2620 | 16839 | 0 | 1259 | 16835 | 0 | m
2620 | 16840 | 0 | 1259 | 16835 | 0 | m
2620 | 16841 | 0 | 1259 | 16835 | 0 | m
2620 | 16842 | 0 | 1259 | 16835 | 0 | m
2620 | 16843 | 0 | 1259 | 16835 | 0 | m
2620 | 16844 | 0 | 1259 | 16835 | 0 | m
2620 | 16845 | 0 | 1259 | 16835 | 0 | m
2620 | 16846 | 0 | 1259 | 16835 | 0 | m
2620 | 16847 | 0 | 1259 | 16835 | 0 | m
2620 | 16848 | 0 | 1259 | 16835 | 0 | m
2620 | 16849 | 0 | 1259 | 16835 | 0 | m
2620 | 16850 | 0 | 1259 | 16835 | 0 | m
(15 rows)

test=# REFRESH MATERIALIZED VIEW immv;
REFRESH MATERIALIZED VIEW
test=# SELECT * FROM pg_depend WHERE refobjid = 'immv'::regclass;
classid | objid | objsubid | refclassid | refobjid | refobjsubid | deptype
---------+-------+----------+------------+----------+-------------+---------
1247 | 16837 | 0 | 1259 | 16835 | 0 | i
2618 | 16838 | 0 | 1259 | 16835 | 0 | i
2618 | 16838 | 0 | 1259 | 16835 | 0 | n
2620 | 16854 | 0 | 1259 | 16835 | 0 | m
2620 | 16855 | 0 | 1259 | 16835 | 0 | m
2620 | 16856 | 0 | 1259 | 16835 | 0 | m
2620 | 16857 | 0 | 1259 | 16835 | 0 | m
2620 | 16858 | 0 | 1259 | 16835 | 0 | m
2620 | 16859 | 0 | 1259 | 16835 | 0 | m
2620 | 16860 | 0 | 1259 | 16835 | 0 | m
2620 | 16861 | 0 | 1259 | 16835 | 0 | m
2620 | 16862 | 0 | 1259 | 16835 | 0 | m
2620 | 16863 | 0 | 1259 | 16835 | 0 | m
2620 | 16864 | 0 | 1259 | 16835 | 0 | m
2620 | 16865 | 0 | 1259 | 16835 | 0 | m
(15 rows)

test=# REFRESH MATERIALIZED VIEW immv WITH NO DATA;
REFRESH MATERIALIZED VIEW
test=# SELECT * FROM pg_depend WHERE refobjid = 'immv'::regclass;
classid | objid | objsubid | refclassid | refobjid | refobjsubid | deptype
---------+-------+----------+------------+----------+-------------+---------
1247 | 16837 | 0 | 1259 | 16835 | 0 | i
2618 | 16838 | 0 | 1259 | 16835 | 0 | i
2618 | 16838 | 0 | 1259 | 16835 | 0 | n
(3 rows)

test=# SELECT * FROM immv;
ERROR: materialized view "immv" has not been populated
HINT: Use the REFRESH MATERIALIZED VIEW command.