### PR TITLE
LIMIT/OFFSET clause is not allowd with IVM

### DIFF
--- a/doc/src/sgml/ref/create_materialized_view.sgml
+++ b/doc/src/sgml/ref/create_materialized_view.sgml
@@ -282,6 +282,16 @@ ERROR:  system column is not supported with IVM
 
        <listitem>
         <para>
+         IMMV including non-immutable functions is not supported.
+         <programlisting>
+CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm12 AS SELECT i,j FROM mv_base_a WHERE i = random()::int;
+ERROR:  functions in IMMV must be marked IMMUTABLE
+         </programlisting>
+        </para>
+        </listitem>
+
+       <listitem>
+        <para>
          IMMVs not supported by logical replication.
         </para>
         </listitem>

--- a/doc/src/sgml/ref/create_materialized_view.sgml
+++ b/doc/src/sgml/ref/create_materialized_view.sgml
@@ -235,7 +235,7 @@ a, (SELECT i, COUNT(*) FROM mv_base_b GROUP BY i) b WHERE a.i = b.i;
         </listitem>
        <listitem>
         <para>
-         CTE, WINDOW clause.
+         CTE, WINDOW, LIMIT and OFFSET clause.
         </para>
        </listitem>
       </itemizedlist>

--- a/doc/src/sgml/rules.sgml
+++ b/doc/src/sgml/rules.sgml
@@ -1436,6 +1436,12 @@ Time: 16386.245 ms (00:16.386)
 
         <listitem>
           <para>
+            LIMIT and OFFSET clause cannot be used.
+          </para>
+        </listitem>
+
+        <listitem>
+          <para>
             <acronym>IMMV</acronym> cannot contain system columns.
           </para>
         </listitem>

--- a/doc/src/sgml/rules.sgml
+++ b/doc/src/sgml/rules.sgml
@@ -1448,6 +1448,12 @@ Time: 16386.245 ms (00:16.386)
 
         <listitem>
           <para>
+            <acronym>IMMV</acronym> cannot contain non-immutable functions.
+          </para>
+        </listitem>
+
+        <listitem>
+          <para>
               Logical replication is not supported, that is, even when a base table
                at a publisher node is modified, <acronym>IMMV</acronym>s at subscriber
                nodes are not updated.

--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -1037,6 +1037,8 @@ check_ivm_restriction_walker(Node *node, check_ivm_restriction_context *ctx, int
 				/* There is a possibility that we don't need to return an error */
 				if (qry->sortClause != NIL)
 					ereport(ERROR, (errmsg("ORDER BY clause is not supported with IVM")));
+				if (qry->limitOffset != NULL || qry->limitCount != NULL)
+					ereport(ERROR, (errmsg("LIMIT/OFFSET clause is not supported with IVM")));
 				if (depth > 0 && qry->hasAggs)
 					ereport(ERROR, (errmsg("aggregate functions in nested query are not supported with IVM")));
 

--- a/src/test/regress/expected/incremental_matview.out
+++ b/src/test/regress/expected/incremental_matview.out
@@ -5186,6 +5186,9 @@ ERROR:  nested subquery is not supported by IVM
 -- contain mutable functions
 CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm12 AS SELECT i,j FROM mv_base_a WHERE i = random()::int;
 ERROR:  functions in IMMV must be marked IMMUTABLE
+-- LIMIT/OFFSET is not supported
+CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm13 AS SELECT i,j FROM mv_base_a LIMIT 10 OFFSET 5;
+ERROR:  LIMIT/OFFSET clause is not supported with IVM
 DROP TABLE mv_base_b CASCADE;
 NOTICE:  drop cascades to 3 other objects
 DETAIL:  drop cascades to materialized view mv_ivm_1

--- a/src/test/regress/sql/incremental_matview.sql
+++ b/src/test/regress/sql/incremental_matview.sql
@@ -1455,5 +1455,8 @@ CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm11 AS SELECT a.i,a.j FROM mv_base_a 
 -- contain mutable functions
 CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm12 AS SELECT i,j FROM mv_base_a WHERE i = random()::int;
 
+-- LIMIT/OFFSET is not supported
+CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm13 AS SELECT i,j FROM mv_base_a LIMIT 10 OFFSET 5;
+
 DROP TABLE mv_base_b CASCADE;
 DROP TABLE mv_base_a CASCADE;


### PR DESCRIPTION
Add restriction of IVM. LIMIT and OFFSET clause can't use incremantal view maintanance.
In addition, add a discription of IVM restriction.

This issue is reported by nuko-san in issue #62 