### PR TITLE
Prohibit rename and unique index creation on IVM columns

### DIFF
--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -36,6 +36,7 @@
 #include "commands/dbcommands.h"
 #include "commands/defrem.h"
 #include "commands/event_trigger.h"
+#include "commands/matview.h"
 #include "commands/progress.h"
 #include "commands/tablecmds.h"
 #include "commands/tablespace.h"
@@ -931,6 +932,45 @@ DefineIndex(Oid relationId,
 						 errmsg("index creation on system columns is not supported")));
 		}
 	}
+
+	/*
+	 * We disallow unique indexes on IVM columns of IMMVs.
+	 */
+	if (RelationIsIVM(rel) && stmt->unique)
+	{
+		for (i = 0; i < indexInfo->ii_NumIndexKeyAttrs; i++)
+		{
+			AttrNumber	attno = indexInfo->ii_IndexAttrNumbers[i];
+			if (attno > 0)
+			{
+				char *name = NameStr(TupleDescAttr(rel->rd_att, attno - 1)->attname);
+				if (name && isIvmColumn(name))
+					ereport(ERROR,
+							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+							 errmsg("unique index creation on IVM columns is not supported")));
+			}
+		}
+
+		if (indexInfo->ii_Expressions)
+		{
+			Bitmapset  *indexattrs = NULL;
+			int			varno = -1;
+
+			pull_varattnos((Node *) indexInfo->ii_Expressions, 1, &indexattrs);
+
+			while ((varno = bms_next_member(indexattrs, varno)) >= 0)
+			{
+				int attno = varno + FirstLowInvalidHeapAttributeNumber;
+				char *name = NameStr(TupleDescAttr(rel->rd_att, attno - 1)->attname);
+				if (name && isIvmColumn(name))
+					ereport(ERROR,
+							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+							 errmsg("unique index creation on IVM columns is not supported")));
+			}
+
+		}
+	}
+
 
 	/*
 	 * Report index creation if appropriate (delay this till after most of the

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -50,6 +50,7 @@
 #include "commands/cluster.h"
 #include "commands/comment.h"
 #include "commands/defrem.h"
+#include "commands/matview.h"
 #include "commands/event_trigger.h"
 #include "commands/policy.h"
 #include "commands/sequence.h"
@@ -2993,6 +2994,14 @@ renameatt_internal(Oid myrelid,
 	 */
 	targetrelation = relation_open(myrelid, AccessExclusiveLock);
 	renameatt_check(myrelid, RelationGetForm(targetrelation), recursing);
+
+	/*
+	 * Don't rename IVM columns.
+	 */
+	if (RelationIsIVM(targetrelation) && isIvmColumn(oldattname))
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("IVM column can not be renamed")));
 
 	/*
 	 * if the 'recurse' flag is set then we are supposed to rename this

--- a/src/test/regress/expected/incremental_matview.out
+++ b/src/test/regress/expected/incremental_matview.out
@@ -70,6 +70,16 @@ SELECT * FROM mv_ivm_1 ORDER BY 1,2,3;
  4 | 40 | 104
 (4 rows)
 
+-- rename of IVM columns
+ALTER MATERIALIZED VIEW mv_ivm_1 RENAME COLUMN __ivm_count__ TO xxx;
+ERROR:  IVM column can not be renamed
+-- unique index on IVM columns
+CREATE UNIQUE INDEX ON mv_ivm_1(__ivm_count__);
+ERROR:  unique index creation on IVM columns is not supported
+CREATE UNIQUE INDEX ON mv_ivm_1((__ivm_count__));
+ERROR:  unique index creation on IVM columns is not supported
+CREATE UNIQUE INDEX ON mv_ivm_1((__ivm_count__ + 1));
+ERROR:  unique index creation on IVM columns is not supported
 -- result of materliazied view have DISTINCT clause or the duplicate result.
 BEGIN;
 CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_duplicate AS SELECT j FROM mv_base_a;

--- a/src/test/regress/sql/incremental_matview.sql
+++ b/src/test/regress/sql/incremental_matview.sql
@@ -28,6 +28,14 @@ SELECT * FROM mv_ivm_1 ORDER BY 1,2,3;
 ROLLBACK;
 SELECT * FROM mv_ivm_1 ORDER BY 1,2,3;
 
+-- rename of IVM columns
+ALTER MATERIALIZED VIEW mv_ivm_1 RENAME COLUMN __ivm_count__ TO xxx;
+
+-- unique index on IVM columns
+CREATE UNIQUE INDEX ON mv_ivm_1(__ivm_count__);
+CREATE UNIQUE INDEX ON mv_ivm_1((__ivm_count__));
+CREATE UNIQUE INDEX ON mv_ivm_1((__ivm_count__ + 1));
+
 -- result of materliazied view have DISTINCT clause or the duplicate result.
 BEGIN;
 CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_duplicate AS SELECT j FROM mv_base_a;


### PR DESCRIPTION
When a user make a unique index on __ivm_count__, IVM will fail due to
the unique constraint violation, so unique index creation must be prohibited.
Also, rename of these columns also causes IVM fails, so must be prohibited, too.

GitHub issues #55