### PR TITLE
Fix incorrect WHERE condition check for outer-join views

### DIFF
--- a/doc/src/sgml/ref/create_materialized_view.sgml
+++ b/doc/src/sgml/ref/create_materialized_view.sgml
@@ -127,7 +127,7 @@ CREATE INCREMENTAL MATERIALIZED VIEW mv(a,b) AS SELECT a.i, b.i FROM mv_base_a
 a LEFT JOIN mv_base_b b ON a.i=b.i WHERE k IS NULL;
 ERROR:  WHERE cannot contain non null-rejecting predicates for IVM with outer join
 CREATE INCREMENTAL MATERIALIZED VIEW mv(a,b) AS SELECT a.i, b.i FROM mv_base_a
-a LEFT JOIN mv_base_b b ON a.i=b.i WHERE (k > 10 OR k = -1);
+a LEFT JOIN mv_base_b b ON a.i=b.i WHERE (k > 0 OR j > 0);
 ERROR:  WHERE cannot contain non null-rejecting predicates for IVM with outer join
             </programlisting>
            </para>

--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -1143,7 +1143,7 @@ check_ivm_restriction_walker(Node *node, check_ivm_restriction_context *ctx, int
 
 					where_quals_vars = pull_vars_of_level(flatten_join_alias_vars(qry, (Node *) qry->jointree->quals), 0);
 
-					if (list_length(where_quals_vars) > list_length(nonnullable_vars))
+					if (list_length(list_difference(where_quals_vars, nonnullable_vars)) > 0)
 						ereport(ERROR, (errmsg("WHERE cannot contain non null-rejecting predicates for IVM with outer join")));
 
 					if (contain_nonstrict_functions((Node *) qry->targetList))

--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -2554,6 +2554,7 @@ multiply_terms(Query *query, List *terms1, List *terms2, Node* qual)
 			/*
 			 * If the relids in the qual are not included, this term can not exist
 			 * because this qual references NULL values.
+			 * XXX: we assume that the qual is null-rejecting.
 			 */
 			if (!bms_is_subset(qual_relids, term->relids))
 			{
@@ -2575,7 +2576,7 @@ multiply_terms(Query *query, List *terms1, List *terms2, Node* qual)
 
 			/*
 			 * If the relids in qual are included term1 or term2, the new term joining
-			 * these two term will survive under the condition that the qual is strict.
+			 * these terms will survive under the condition that the qual is null-rejecting.
 			 * Otherwise, the new term can not exist because the qual references NULL
 			 * values.
 			 */
@@ -3923,7 +3924,6 @@ insert_dangling_tuples(IvmMaintenanceGraph *graph, Query *query,
 		char *sep = "";
 		char *sep2 = "";
 		int		i;
-
 
 		if (term->effect != IVM_INDIRECT_EFFECT)
 			continue;

--- a/src/test/regress/expected/incremental_matview.out
+++ b/src/test/regress/expected/incremental_matview.out
@@ -5202,7 +5202,7 @@ ERROR:  Only simple equijoin is supported for IVM with outer join
 -- outer join view's WHERE clause cannot contain non null-rejecting predicates
 CREATE INCREMENTAL MATERIALIZED VIEW mv(a,b) AS SELECT a.i, b.i FROM mv_base_a a LEFT JOIN mv_base_b b ON a.i=b.i WHERE k IS NULL;
 ERROR:  WHERE cannot contain non null-rejecting predicates for IVM with outer join
-CREATE INCREMENTAL MATERIALIZED VIEW mv(a,b) AS SELECT a.i, b.i FROM mv_base_a a LEFT JOIN mv_base_b b ON a.i=b.i WHERE (k > 10 OR k = -1);
+CREATE INCREMENTAL MATERIALIZED VIEW mv(a,b) AS SELECT a.i, b.i FROM mv_base_a a LEFT JOIN mv_base_b b ON a.i=b.i WHERE (k > 0 OR j > 0);
 ERROR:  WHERE cannot contain non null-rejecting predicates for IVM with outer join
 -- aggregate is not supported with outer join
 CREATE INCREMENTAL MATERIALIZED VIEW mv(a,b,v) AS SELECT a.i, b.i, sum(k) FROM mv_base_a a LEFT JOIN mv_base_b b ON a.i=b.i GROUP BY a.i, b.i;

--- a/src/test/regress/sql/incremental_matview.sql
+++ b/src/test/regress/sql/incremental_matview.sql
@@ -1477,7 +1477,7 @@ CREATE INCREMENTAL MATERIALIZED VIEW mv(a,b,k,j) AS SELECT a.i, b.i, k j FROM mv
 
 -- outer join view's WHERE clause cannot contain non null-rejecting predicates
 CREATE INCREMENTAL MATERIALIZED VIEW mv(a,b) AS SELECT a.i, b.i FROM mv_base_a a LEFT JOIN mv_base_b b ON a.i=b.i WHERE k IS NULL;
-CREATE INCREMENTAL MATERIALIZED VIEW mv(a,b) AS SELECT a.i, b.i FROM mv_base_a a LEFT JOIN mv_base_b b ON a.i=b.i WHERE (k > 10 OR k = -1);
+CREATE INCREMENTAL MATERIALIZED VIEW mv(a,b) AS SELECT a.i, b.i FROM mv_base_a a LEFT JOIN mv_base_b b ON a.i=b.i WHERE (k > 0 OR j > 0);
 
 -- aggregate is not supported with outer join
 CREATE INCREMENTAL MATERIALIZED VIEW mv(a,b,v) AS SELECT a.i, b.i, sum(k) FROM mv_base_a a LEFT JOIN mv_base_b b ON a.i=b.i GROUP BY a.i, b.i;


### PR DESCRIPTION
The check for non null-rejecting condition check was incorrect,
and it raised the error even for null-rejecting cases, especially
when same attribute is referred more then one times in WHERE
clause.

GitHub issue #78