### PR TITLE
Add IVM restrictions

### DIFF
--- a/doc/src/sgml/rules.sgml
+++ b/doc/src/sgml/rules.sgml
@@ -1410,6 +1410,18 @@ Time: 16386.245 ms (00:16.386)
         </para>
         </listitem>
 
+        <listitem>
+        <para>
+            <literal>DISTINCT</literal> cannot be contained in a subquery.
+        </para>
+        </listitem>
+
+        <listitem>
+        <para>
+            Join is not allowed in a subquery.
+        </para>
+        </listitem>
+
     </itemizedlist>
     </para>
     </sect4>
@@ -1450,6 +1462,54 @@ Time: 16386.245 ms (00:16.386)
         <listitem>
           <para>
             <acronym>IMMV</acronym> cannot contain non-immutable functions.
+          </para>
+        </listitem>
+
+        <listitem>
+          <para>
+            UNION/INTERSECT/EXCEPT clause cannnot be used.
+          </para>
+        </listitem>
+
+        <listitem>
+          <para>
+            DISTINCT ON clause cannot be used.
+          </para>
+        </listitem>
+
+        <listitem>
+          <para>
+            TABLESAMPLE parameter cannot be used.
+          </para>
+        </listitem>
+
+        <listitem>
+          <para>
+            inheritance parent table cannnot be used.
+          </para>
+        </listitem>
+
+        <listitem>
+          <para>
+            <literal>GROUPING SETS</literal> and <literal>FILTER</literal> clauses cannot be used.
+          </para>
+        </listitem>
+
+        <listitem>
+          <para>
+            FOR UPDATE/SHARE cannot be used.
+          </para>
+        </listitem>
+
+        <listitem>
+          <para>
+            inheritance parent table cannnot be used.
+          </para>
+        </listitem>
+
+        <listitem>
+          <para>
+            targetlist cannot contain hidden columns which name start with <literal>__ivm_</literal>.
           </para>
         </listitem>
 

--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -1058,10 +1058,10 @@ check_ivm_restriction_walker(Node *node, check_ivm_restriction_context *ctx, int
 				/* if contained CTE, return error */
 				if (qry->cteList != NIL)
 					ereport(ERROR, (errmsg("CTE is not supported with IVM")));
+
 				if (qry->havingQual != NULL)
 					ereport(ERROR, (errmsg(" HAVING clause is not supported with IVM")));
-				/* There is a possibility that we don't need to return an error */
-				if (qry->sortClause != NIL)
+				if (qry->sortClause != NIL)	/* There is a possibility that we don't need to return an error */
 					ereport(ERROR, (errmsg("ORDER BY clause is not supported with IVM")));
 				if (qry->limitOffset != NULL || qry->limitCount != NULL)
 					ereport(ERROR, (errmsg("LIMIT/OFFSET clause is not supported with IVM")));
@@ -1096,7 +1096,7 @@ check_ivm_restriction_walker(Node *node, check_ivm_restriction_context *ctx, int
 
 					if (rte->tablesample != NULL)
 						ereport(ERROR, (errmsg("TABLESAMPLE clause is not supported with IVM")));
-					if (rte->relkind == RELKIND_RELATION && find_inheritance_children(rte->relid, AccessShareLock) != NIL)
+					if (rte->relkind == RELKIND_RELATION && find_inheritance_children(rte->relid, NoLock) != NIL)
 						ereport(ERROR, (errmsg("inheritance parent is not supported with IVM")));
 					if (rte->relkind == RELKIND_VIEW ||
 							rte->relkind == RELKIND_MATVIEW)

--- a/src/test/regress/expected/incremental_matview.out
+++ b/src/test/regress/expected/incremental_matview.out
@@ -80,6 +80,15 @@ CREATE UNIQUE INDEX ON mv_ivm_1((__ivm_count__));
 ERROR:  unique index creation on IVM columns is not supported
 CREATE UNIQUE INDEX ON mv_ivm_1((__ivm_count__ + 1));
 ERROR:  unique index creation on IVM columns is not supported
+-- some query syntax
+BEGIN;
+CREATE FUNCTION ivm_func() RETURNS int LANGUAGE 'sql'
+       AS 'SELECT 1' IMMUTABLE;
+CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_func AS SELECT * FROM ivm_func();
+CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_no_tbl AS SELECT 1;
+CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_only_values1 AS values(1);
+CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_only_values2 AS SELECT * FROM (values(1)) AS tmp;
+ROLLBACK;
 -- result of materliazied view have DISTINCT clause or the duplicate result.
 BEGIN;
 CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_duplicate AS SELECT j FROM mv_base_a;
@@ -5250,6 +5259,51 @@ ERROR:  functions in IMMV must be marked IMMUTABLE
 -- LIMIT/OFFSET is not supported
 CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm13 AS SELECT i,j FROM mv_base_a LIMIT 10 OFFSET 5;
 ERROR:  LIMIT/OFFSET clause is not supported with IVM
+-- DISTINCT ON is not supported
+CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm14 AS SELECT DISTINCT ON(i) i, j FROM mv_base_a;
+ERROR:  DISTINCT ON is not supported with IVM
+-- TABLESAMPLE parameter is not supported
+CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm15 AS SELECT i, j FROM mv_base_a TABLESAMPLE SYSTEM(50);
+ERROR:  TABLESAMPLE parameter is not supported with IVM
+-- window function is not supported
+CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm16 AS SELECT i, j FROM (SELECT *, cume_dist() OVER (ORDER BY i) AS rank FROM mv_base_a) AS t;
+ERROR:  window function is not supported with IVM
+-- aggregate function with some options is not supported
+CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm17 AS SELECT COUNT(*) FILTER(WHERE i < 3) FROM mv_base_a;
+ERROR:  aggregate function with FILTER clause is not supported
+CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm18 AS SELECT COUNT(DISTINCT i)  FROM mv_base_a;
+ERROR:  aggregate function with DISTINCT arguments is not supported
+CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm19 AS SELECT array_agg(j ORDER BY i DESC) FROM mv_base_a;
+ERROR:  aggregate function with ORDER clause is not supported
+CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm20 AS SELECT i,SUM(j) FROM mv_base_a GROUP BY GROUPING SETS((i),());
+ERROR:  GROUPING SETS, ROLLUP, or CUBE clauses are not supported with IVM
+-- inheritance parent is not supported with IVM"
+BEGIN;
+CREATE TABLE parent (i int, v int);
+CREATE TABLE child_a(options text) INHERITS(parent);
+CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm21 AS SELECT * FROM parent;
+ERROR:  inheritance parent is not supported with IVM
+ROLLBACK;
+-- UNION clause is not supported
+CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm22 AS SELECT i,j FROM mv_base_a UNION ALL SELECT i,k FROM mv_base_b;;
+ERROR:  UNION/INTERSECT/EXCEPT query are not supported with IVM
+-- DISTINCT cluase in nested query are not supported
+CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm23 AS SELECT * FROM (SELECT DISTINCT i,j FROM mv_base_a) AS tmp;
+ERROR:  DISTINCT cluase in nested query are not supported with IVM
+-- multiple tables contained in nested query are not supported
+CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm24 AS SELECT * FROM (SELECT i,j,k FROM mv_base_a INNER JOIN mv_base_b USING(i)) AS tmp;
+ERROR:  multiple tables contained in nested query are not supported with IVM
+-- empty target list is not allowed with IVM
+CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm25 AS SELECT FROM mv_base_a;
+ERROR:  empty target list is not allowed with IVM
+-- FOR UPDATE/SHARE is not supported
+CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm26 AS SELECT i,j FROM mv_base_a FOR UPDATE;
+ERROR:  FOR UPDATE/SHARE clause is not supported with IVM
+CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm27 AS SELECT * FROM (SELECT i,j FROM mv_base_a FOR UPDATE) AS tmp;
+ERROR:  FOR UPDATE/SHARE clause is not supported with IVM
+-- tartget list cannot contain ivm clumn that start with '__ivm'
+CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm28 AS SELECT i AS "__ivm_count__" FROM mv_base_a;
+ERROR:  IMMV cannot contain column name __ivm_count__
 -- base table has row level security
 DROP USER IF EXISTS ivm_admin;
 NOTICE:  role "ivm_admin" does not exist, skipping

--- a/src/test/regress/expected/incremental_matview.out
+++ b/src/test/regress/expected/incremental_matview.out
@@ -5262,12 +5262,12 @@ ERROR:  LIMIT/OFFSET clause is not supported with IVM
 -- DISTINCT ON is not supported
 CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm14 AS SELECT DISTINCT ON(i) i, j FROM mv_base_a;
 ERROR:  DISTINCT ON is not supported with IVM
--- TABLESAMPLE parameter is not supported
+-- TABLESAMPLE clause is not supported
 CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm15 AS SELECT i, j FROM mv_base_a TABLESAMPLE SYSTEM(50);
-ERROR:  TABLESAMPLE parameter is not supported with IVM
--- window function is not supported
+ERROR:  TABLESAMPLE clause is not supported with IVM
+-- window functions are not supported
 CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm16 AS SELECT i, j FROM (SELECT *, cume_dist() OVER (ORDER BY i) AS rank FROM mv_base_a) AS t;
-ERROR:  window function is not supported with IVM
+ERROR:  window functions are not supported with IVM
 -- aggregate function with some options is not supported
 CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm17 AS SELECT COUNT(*) FILTER(WHERE i < 3) FROM mv_base_a;
 ERROR:  aggregate function with FILTER clause is not supported
@@ -5276,7 +5276,7 @@ ERROR:  aggregate function with DISTINCT arguments is not supported
 CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm19 AS SELECT array_agg(j ORDER BY i DESC) FROM mv_base_a;
 ERROR:  aggregate function with ORDER clause is not supported
 CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm20 AS SELECT i,SUM(j) FROM mv_base_a GROUP BY GROUPING SETS((i),());
-ERROR:  GROUPING SETS, ROLLUP, or CUBE clauses are not supported with IVM
+ERROR:  GROUPING SETS, ROLLUP, or CUBE clauses is not supported with IVM
 -- inheritance parent is not supported with IVM"
 BEGIN;
 CREATE TABLE parent (i int, v int);
@@ -5284,9 +5284,9 @@ CREATE TABLE child_a(options text) INHERITS(parent);
 CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm21 AS SELECT * FROM parent;
 ERROR:  inheritance parent is not supported with IVM
 ROLLBACK;
--- UNION clause is not supported
+-- UNION statement is not supported
 CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm22 AS SELECT i,j FROM mv_base_a UNION ALL SELECT i,k FROM mv_base_b;;
-ERROR:  UNION/INTERSECT/EXCEPT query are not supported with IVM
+ERROR:  UNION/INTERSECT/EXCEPT statements are not supported with IVM
 -- DISTINCT cluase in nested query are not supported
 CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm23 AS SELECT * FROM (SELECT DISTINCT i,j FROM mv_base_a) AS tmp;
 ERROR:  DISTINCT cluase in nested query are not supported with IVM

--- a/src/test/regress/sql/incremental_matview.sql
+++ b/src/test/regress/sql/incremental_matview.sql
@@ -36,6 +36,16 @@ CREATE UNIQUE INDEX ON mv_ivm_1(__ivm_count__);
 CREATE UNIQUE INDEX ON mv_ivm_1((__ivm_count__));
 CREATE UNIQUE INDEX ON mv_ivm_1((__ivm_count__ + 1));
 
+-- some query syntax
+BEGIN;
+CREATE FUNCTION ivm_func() RETURNS int LANGUAGE 'sql'
+       AS 'SELECT 1' IMMUTABLE;
+CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_func AS SELECT * FROM ivm_func();
+CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_no_tbl AS SELECT 1;
+CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_only_values1 AS values(1);
+CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_only_values2 AS SELECT * FROM (values(1)) AS tmp;
+ROLLBACK;
+
 -- result of materliazied view have DISTINCT clause or the duplicate result.
 BEGIN;
 CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_duplicate AS SELECT j FROM mv_base_a;
@@ -1513,6 +1523,47 @@ CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm12 AS SELECT i,j FROM mv_base_a WHER
 
 -- LIMIT/OFFSET is not supported
 CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm13 AS SELECT i,j FROM mv_base_a LIMIT 10 OFFSET 5;
+
+-- DISTINCT ON is not supported
+CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm14 AS SELECT DISTINCT ON(i) i, j FROM mv_base_a;
+
+-- TABLESAMPLE parameter is not supported
+CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm15 AS SELECT i, j FROM mv_base_a TABLESAMPLE SYSTEM(50);
+
+-- window function is not supported
+CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm16 AS SELECT i, j FROM (SELECT *, cume_dist() OVER (ORDER BY i) AS rank FROM mv_base_a) AS t;
+
+-- aggregate function with some options is not supported
+CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm17 AS SELECT COUNT(*) FILTER(WHERE i < 3) FROM mv_base_a;
+CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm18 AS SELECT COUNT(DISTINCT i)  FROM mv_base_a;
+CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm19 AS SELECT array_agg(j ORDER BY i DESC) FROM mv_base_a;
+CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm20 AS SELECT i,SUM(j) FROM mv_base_a GROUP BY GROUPING SETS((i),());
+
+-- inheritance parent is not supported with IVM"
+BEGIN;
+CREATE TABLE parent (i int, v int);
+CREATE TABLE child_a(options text) INHERITS(parent);
+CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm21 AS SELECT * FROM parent;
+ROLLBACK;
+
+-- UNION clause is not supported
+CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm22 AS SELECT i,j FROM mv_base_a UNION ALL SELECT i,k FROM mv_base_b;;
+
+-- DISTINCT cluase in nested query are not supported
+CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm23 AS SELECT * FROM (SELECT DISTINCT i,j FROM mv_base_a) AS tmp;
+
+-- multiple tables contained in nested query are not supported
+CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm24 AS SELECT * FROM (SELECT i,j,k FROM mv_base_a INNER JOIN mv_base_b USING(i)) AS tmp;
+
+-- empty target list is not allowed with IVM
+CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm25 AS SELECT FROM mv_base_a;
+
+-- FOR UPDATE/SHARE is not supported
+CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm26 AS SELECT i,j FROM mv_base_a FOR UPDATE;
+CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm27 AS SELECT * FROM (SELECT i,j FROM mv_base_a FOR UPDATE) AS tmp;
+
+-- tartget list cannot contain ivm clumn that start with '__ivm'
+CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm28 AS SELECT i AS "__ivm_count__" FROM mv_base_a;
 
 -- base table has row level security
 DROP USER IF EXISTS ivm_admin;

--- a/src/test/regress/sql/incremental_matview.sql
+++ b/src/test/regress/sql/incremental_matview.sql
@@ -1527,10 +1527,10 @@ CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm13 AS SELECT i,j FROM mv_base_a LIMI
 -- DISTINCT ON is not supported
 CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm14 AS SELECT DISTINCT ON(i) i, j FROM mv_base_a;
 
--- TABLESAMPLE parameter is not supported
+-- TABLESAMPLE clause is not supported
 CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm15 AS SELECT i, j FROM mv_base_a TABLESAMPLE SYSTEM(50);
 
--- window function is not supported
+-- window functions are not supported
 CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm16 AS SELECT i, j FROM (SELECT *, cume_dist() OVER (ORDER BY i) AS rank FROM mv_base_a) AS t;
 
 -- aggregate function with some options is not supported
@@ -1546,7 +1546,7 @@ CREATE TABLE child_a(options text) INHERITS(parent);
 CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm21 AS SELECT * FROM parent;
 ROLLBACK;
 
--- UNION clause is not supported
+-- UNION statement is not supported
 CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm22 AS SELECT i,j FROM mv_base_a UNION ALL SELECT i,k FROM mv_base_b;;
 
 -- DISTINCT cluase in nested query are not supported


### PR DESCRIPTION
Add following restrictions:
- DISTINCT ON
- TABLESAMPLE parameter
- inheritance parent table
- window function
- some aggregate options(such as FILTER, DISTINCT, ORDER and GROUPING SETS)
- targetlist containing IVM column
- simple subquery is only supported
- FOR UPDATE/SHARE
- empty target list
- UNION/INTERSECT/EXCEPT
- GROUPING SETS clauses