### PR TITLE
Fix rte_path bug

### DIFF
--- a/doc/src/sgml/rules.sgml
+++ b/doc/src/sgml/rules.sgml
@@ -1418,7 +1418,7 @@ Time: 16386.245 ms (00:16.386)
 
         <listitem>
         <para>
-            Join is not allowed in a subquery.
+            subqueres containing table join are only allowed in FROM clause.
         </para>
         </listitem>
 
@@ -1498,12 +1498,6 @@ Time: 16386.245 ms (00:16.386)
         <listitem>
           <para>
             FOR UPDATE/SHARE cannot be used.
-          </para>
-        </listitem>
-
-        <listitem>
-          <para>
-            inheritance parent table cannnot be used.
           </para>
         </listitem>
 

--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -1081,9 +1081,6 @@ check_ivm_restriction_walker(Node *node, check_ivm_restriction_context *ctx, int
 				/* subquery restrictions */
 				if (depth > 0 && qry->distinctClause != NIL)
 					ereport(ERROR, (errmsg("DISTINCT cluase in nested query are not supported with IVM")));
-				if (depth > 0 && list_length(qry->rtable) > 1)
-					ereport(ERROR, (errmsg("multiple tables contained in nested query are not supported with IVM")));
-
 				if (depth > 0 && qry->hasAggs)
 					ereport(ERROR, (errmsg("aggregate functions in nested query are not supported with IVM")));
 

--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -1710,7 +1710,7 @@ rewrite_query_for_preupdate_state(Query *query, List *tables,
 
 		/* if rte contains subquery, search recursively */
 		if (r->rtekind == RTE_SUBQUERY)
-			rewrite_query_for_preupdate_state(r->subquery, tables, xid, cid, pstate, lappend_int(rte_path, i));
+			rewrite_query_for_preupdate_state(r->subquery, tables, xid, cid, pstate, lappend_int(list_copy(rte_path), i));
 		else
 		{
 			ListCell *lc2;
@@ -1724,7 +1724,7 @@ rewrite_query_for_preupdate_state(Query *query, List *tables,
 				if (r->relid == table->table_id)
 				{
 					lfirst(lc) = get_prestate_rte(r, table, xid, cid, pstate->p_queryEnv);
-					table->rte_paths = lappend(table->rte_paths, lappend_int(rte_path, i));
+					table->rte_paths = lappend(table->rte_paths, lappend_int(list_copy(rte_path), i));
 					break;
 				}
 			}

--- a/src/test/regress/expected/incremental_matview.out
+++ b/src/test/regress/expected/incremental_matview.out
@@ -575,6 +575,31 @@ SELECT * FROM mv_ivm_subquery ORDER BY i,j;
 (6 rows)
 
 ROLLBACK;
+-- support join subquery in FROM cluase
+BEGIN;
+CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm_join_subquery AS SELECT i, j, k FROM ( SELECT i, a.j, b.k FROM mv_base_b b INNER JOIN mv_base_a a USING(i)) tmp;
+WITH
+ ai AS (INSERT INTO mv_base_a VALUES (1,11),(2,22) RETURNING 0),
+ bi AS (INSERT INTO mv_base_b VALUES (1,111),(3,133) RETURNING 0),
+ bd AS (DELETE FROM mv_base_b WHERE i = 4 RETURNING 0)
+SELECT;
+--
+(1 row)
+
+SELECT * FROM mv_ivm_join_subquery ORDER BY i,j,k;
+ i | j  |  k  
+---+----+-----
+ 1 | 10 | 101
+ 1 | 10 | 111
+ 1 | 11 | 101
+ 1 | 11 | 111
+ 2 | 20 | 102
+ 2 | 22 | 102
+ 3 | 30 | 103
+ 3 | 30 | 133
+(8 rows)
+
+ROLLBACK;
 -- views including NULL
 BEGIN;
 CREATE TABLE t (i int, v int);
@@ -5290,9 +5315,6 @@ ERROR:  UNION/INTERSECT/EXCEPT statements are not supported with IVM
 -- DISTINCT cluase in nested query are not supported
 CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm23 AS SELECT * FROM (SELECT DISTINCT i,j FROM mv_base_a) AS tmp;
 ERROR:  DISTINCT cluase in nested query are not supported with IVM
--- multiple tables contained in nested query are not supported
-CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm24 AS SELECT * FROM (SELECT i,j,k FROM mv_base_a INNER JOIN mv_base_b USING(i)) AS tmp;
-ERROR:  multiple tables contained in nested query are not supported with IVM
 -- empty target list is not allowed with IVM
 CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm25 AS SELECT FROM mv_base_a;
 ERROR:  empty target list is not allowed with IVM

--- a/src/test/regress/sql/incremental_matview.sql
+++ b/src/test/regress/sql/incremental_matview.sql
@@ -222,6 +222,18 @@ SELECT * FROM mv_ivm_subquery ORDER BY i,j;
 
 ROLLBACK;
 
+-- support join subquery in FROM cluase
+BEGIN;
+CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm_join_subquery AS SELECT i, j, k FROM ( SELECT i, a.j, b.k FROM mv_base_b b INNER JOIN mv_base_a a USING(i)) tmp;
+WITH
+ ai AS (INSERT INTO mv_base_a VALUES (1,11),(2,22) RETURNING 0),
+ bi AS (INSERT INTO mv_base_b VALUES (1,111),(3,133) RETURNING 0),
+ bd AS (DELETE FROM mv_base_b WHERE i = 4 RETURNING 0)
+SELECT;
+SELECT * FROM mv_ivm_join_subquery ORDER BY i,j,k;
+
+ROLLBACK;
+
 -- views including NULL
 BEGIN;
 CREATE TABLE t (i int, v int);
@@ -1551,9 +1563,6 @@ CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm22 AS SELECT i,j FROM mv_base_a UNIO
 
 -- DISTINCT cluase in nested query are not supported
 CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm23 AS SELECT * FROM (SELECT DISTINCT i,j FROM mv_base_a) AS tmp;
-
--- multiple tables contained in nested query are not supported
-CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm24 AS SELECT * FROM (SELECT i,j,k FROM mv_base_a INNER JOIN mv_base_b USING(i)) AS tmp;
 
 -- empty target list is not allowed with IVM
 CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm25 AS SELECT FROM mv_base_a;


### PR DESCRIPTION
A bug of rte_paths is fixed this.

when multi tables is updated together, IMMV data is not correct, because recurrence processing didn't consider this case.

An inner join in subquery is able to be supported by this fix.