### PR TITLE
Fix incorrect results of aggregate views withoug GROUP BY

### DIFF
--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -3457,18 +3457,14 @@ apply_old_delta(const char *matviewname, const char *deltaname_old,
 	if (SPI_exec(querybuf.data, 0) != SPI_OK_SELECT)
 		elog(ERROR, "SPI_exec failed: %s", querybuf.data);
 
+	Assert(tuptable_recalce != NULL);
+
 	if (minmax_list)
-	{
-		if (tuptable_recalc)
-			*tuptable_recalc = SPI_tuptable;
-		return SPI_processed;
-	}
+		*tuptable_recalc = SPI_tuptable;
 	else
-	{
-		if (tuptable_recalc)
-			*tuptable_recalc = NULL;
-		return 0;
-	}
+		*tuptable_recalc = NULL;
+
+	return (minmax_list ? SPI_processed : 0);
 }
 
 /*

--- a/src/test/regress/expected/incremental_matview.out
+++ b/src/test/regress/expected/incremental_matview.out
@@ -137,9 +137,9 @@ SELECT * FROM mv_ivm_distinct ORDER BY 1;
 (5 rows)
 
 ROLLBACK;
--- support SUM(), COUNT() and AVG() aggregation function
+-- support SUM(), COUNT() and AVG() aggregate functions
 BEGIN;
-CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_agg AS SELECT i, SUM(j), COUNT(i),AVG(j)  FROM mv_base_a GROUP BY i;
+CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_agg AS SELECT i, SUM(j), COUNT(i), AVG(j) FROM mv_base_a GROUP BY i;
 SELECT * FROM mv_ivm_agg ORDER BY 1,2,3,4;
  i | sum | count |         avg         
 ---+-----+-------+---------------------
@@ -184,9 +184,9 @@ SELECT * FROM mv_ivm_agg ORDER BY 1,2,3,4;
 (5 rows)
 
 ROLLBACK;
--- support COUNT(*) aggregation function
+-- support COUNT(*) aggregate function
 BEGIN;
-CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_agg AS SELECT i, SUM(j),COUNT(*)  FROM mv_base_a GROUP BY i;
+CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_agg AS SELECT i, SUM(j), COUNT(*) FROM mv_base_a GROUP BY i;
 SELECT * FROM mv_ivm_agg ORDER BY 1,2,3;
  i | sum | count 
 ---+-----+-------
@@ -209,20 +209,27 @@ SELECT * FROM mv_ivm_agg ORDER BY 1,2,3;
 (5 rows)
 
 ROLLBACK;
--- support having only aggregation function without GROUP clause
+-- support aggregate functions without GROUP clause
 BEGIN;
-CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_group AS SELECT SUM(j)FROM mv_base_a;
+CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_group AS SELECT SUM(j), COUNT(j), AVG(j) FROM mv_base_a;
 SELECT * FROM mv_ivm_group ORDER BY 1;
- sum 
------
- 150
+ sum | count |         avg         
+-----+-------+---------------------
+ 150 |     5 | 30.0000000000000000
 (1 row)
 
-INSERT INTO mv_base_a VALUES(6,20);
+INSERT INTO mv_base_a VALUES(6,60);
 SELECT * FROM mv_ivm_group ORDER BY 1;
- sum 
------
- 170
+ sum | count |         avg         
+-----+-------+---------------------
+ 210 |     6 | 35.0000000000000000
+(1 row)
+
+DELETE FROM mv_base_a;
+SELECT * FROM mv_ivm_group ORDER BY 1;
+ sum | count | avg 
+-----+-------+-----
+     |     0 |    
 (1 row)
 
 ROLLBACK;
@@ -267,7 +274,7 @@ SELECT * FROM mv_ivm_avg_bug ORDER BY 1,2,3;
 (5 rows)
 
 ROLLBACK;
--- support MIN(), MAX() aggregation functions
+-- support MIN(), MAX() aggregate functions
 BEGIN;
 CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_min_max AS SELECT i, MIN(j), MAX(j)  FROM mv_base_a GROUP BY i;
 SELECT * FROM mv_ivm_min_max ORDER BY 1,2,3;
@@ -308,7 +315,7 @@ SELECT * FROM mv_ivm_min_max ORDER BY 1,2,3;
 (5 rows)
 
 ROLLBACK;
--- support MIN(), MAX() aggregation functions without GROUP clause
+-- support MIN(), MAX() aggregate functions without GROUP clause
 BEGIN;
 CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_min_max AS SELECT MIN(j), MAX(j)  FROM mv_base_a;
 SELECT * FROM mv_ivm_min_max;
@@ -330,6 +337,13 @@ SELECT * FROM mv_ivm_min_max;
  min | max 
 -----+-----
   10 |  60
+(1 row)
+
+DELETE FROM mv_base_a;
+SELECT * FROM mv_ivm_min_max;
+ min | max 
+-----+-----
+     |    
 (1 row)
 
 ROLLBACK;

--- a/src/test/regress/sql/incremental_matview.sql
+++ b/src/test/regress/sql/incremental_matview.sql
@@ -58,9 +58,9 @@ SELECT * FROM mv_ivm_duplicate ORDER BY 1;
 SELECT * FROM mv_ivm_distinct ORDER BY 1;
 ROLLBACK;
 
--- support SUM(), COUNT() and AVG() aggregation function
+-- support SUM(), COUNT() and AVG() aggregate functions
 BEGIN;
-CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_agg AS SELECT i, SUM(j), COUNT(i),AVG(j)  FROM mv_base_a GROUP BY i;
+CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_agg AS SELECT i, SUM(j), COUNT(i), AVG(j) FROM mv_base_a GROUP BY i;
 SELECT * FROM mv_ivm_agg ORDER BY 1,2,3,4;
 INSERT INTO mv_base_a VALUES(2,100);
 SELECT * FROM mv_ivm_agg ORDER BY 1,2,3,4;
@@ -70,19 +70,21 @@ DELETE FROM mv_base_a WHERE (i,j) = (2,200);
 SELECT * FROM mv_ivm_agg ORDER BY 1,2,3,4;
 ROLLBACK;
 
--- support COUNT(*) aggregation function
+-- support COUNT(*) aggregate function
 BEGIN;
-CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_agg AS SELECT i, SUM(j),COUNT(*)  FROM mv_base_a GROUP BY i;
+CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_agg AS SELECT i, SUM(j), COUNT(*) FROM mv_base_a GROUP BY i;
 SELECT * FROM mv_ivm_agg ORDER BY 1,2,3;
 INSERT INTO mv_base_a VALUES(2,100);
 SELECT * FROM mv_ivm_agg ORDER BY 1,2,3;
 ROLLBACK;
 
--- support having only aggregation function without GROUP clause
+-- support aggregate functions without GROUP clause
 BEGIN;
-CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_group AS SELECT SUM(j)FROM mv_base_a;
+CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_group AS SELECT SUM(j), COUNT(j), AVG(j) FROM mv_base_a;
 SELECT * FROM mv_ivm_group ORDER BY 1;
-INSERT INTO mv_base_a VALUES(6,20);
+INSERT INTO mv_base_a VALUES(6,60);
+SELECT * FROM mv_ivm_group ORDER BY 1;
+DELETE FROM mv_base_a;
 SELECT * FROM mv_ivm_group ORDER BY 1;
 ROLLBACK;
 
@@ -101,7 +103,7 @@ DELETE FROM mv_base_a WHERE (i,j) = (2,30);
 SELECT * FROM mv_ivm_avg_bug ORDER BY 1,2,3;
 ROLLBACK;
 
--- support MIN(), MAX() aggregation functions
+-- support MIN(), MAX() aggregate functions
 BEGIN;
 CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_min_max AS SELECT i, MIN(j), MAX(j)  FROM mv_base_a GROUP BY i;
 SELECT * FROM mv_ivm_min_max ORDER BY 1,2,3;
@@ -116,7 +118,7 @@ DELETE FROM mv_base_a WHERE (i,j) IN ((1,10), (2,21), (3,32));
 SELECT * FROM mv_ivm_min_max ORDER BY 1,2,3;
 ROLLBACK;
 
--- support MIN(), MAX() aggregation functions without GROUP clause
+-- support MIN(), MAX() aggregate functions without GROUP clause
 BEGIN;
 CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_min_max AS SELECT MIN(j), MAX(j)  FROM mv_base_a;
 SELECT * FROM mv_ivm_min_max;
@@ -124,6 +126,8 @@ INSERT INTO mv_base_a VALUES
   (0,0), (6,60), (7,70);
 SELECT * FROM mv_ivm_min_max;
 DELETE FROM mv_base_a WHERE (i,j) IN ((0,0), (7,70));
+SELECT * FROM mv_ivm_min_max;
+DELETE FROM mv_base_a;
 SELECT * FROM mv_ivm_min_max;
 ROLLBACK;
 


### PR DESCRIPTION
Views of aggregate without GROUP BY clause always have
only one tuple as the result. Even when all tuples in base
tables are deleted, the view must have a row whose result is
0 for count(), or NULL for others.

However, in the previous implementation, this resulted in
deleting the tuple from the view.  To fix this, don't allow
to delete a tuple from a view when this is a aggregate view
without GROUP BY.

Github issue #88