### PR TITLE
Fix segment fault is happened

### DIFF
--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -4536,7 +4536,9 @@ getColumnNameStartWith(RangeTblEntry *rte, char *str, int *attnum)
 bool
 isIvmColumn(const char *s)
 {
-	return (strncmp(s, "__ivm_", 6) == 0);
+	if (s)
+		return (strncmp(s, "__ivm_", 6) == 0);
+	return false;
 }
 
 /*

--- a/src/test/regress/expected/incremental_matview.out
+++ b/src/test/regress/expected/incremental_matview.out
@@ -5664,6 +5664,9 @@ ERROR:  FOR UPDATE/SHARE clause is not supported on incrementally maintainable m
 -- tartget list cannot contain ivm clumn that start with '__ivm'
 CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm28 AS SELECT i AS "__ivm_count__" FROM mv_base_a;
 ERROR:  column name __ivm_count__ is not supported on incrementally maintainable materialized view
+-- expressions specified in GROUP BY must appear in the target list.
+CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm29 AS SELECT COUNT(i) FROM mv_base_a GROUP BY i;
+ERROR:  GROUP BY expression not appeared in select list is not supported on incrementally maintainable materialized view
 -- base table has row level security
 DROP USER IF EXISTS ivm_admin;
 NOTICE:  role "ivm_admin" does not exist, skipping

--- a/src/test/regress/sql/incremental_matview.sql
+++ b/src/test/regress/sql/incremental_matview.sql
@@ -1652,6 +1652,9 @@ CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm27 AS SELECT * FROM (SELECT i,j FROM
 -- tartget list cannot contain ivm clumn that start with '__ivm'
 CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm28 AS SELECT i AS "__ivm_count__" FROM mv_base_a;
 
+-- expressions specified in GROUP BY must appear in the target list.
+CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm29 AS SELECT COUNT(i) FROM mv_base_a GROUP BY i;
+
 -- base table has row level security
 DROP USER IF EXISTS ivm_admin;
 DROP USER IF EXISTS ivm_user;


### PR DESCRIPTION
This fix is related by issue #98 .

If MV define has GROUP BY clause, this expression must appear
contained in the arget list. This cause is that isIVMColumn
function which did not check if the resname was null.