### PR TITLE
Fix log hint message

### DIFF
--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -1287,7 +1287,7 @@ check_ivm_restriction_walker(Node *node, check_ivm_restriction_context *ctx, int
 					ereport(ERROR,
 							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 							 errmsg("this query is not allowed on incrementally maintainable materialized view"),
-							 errhint("WHERE clause only support subquery with EXISTS clause")));
+							 errhint("subquery in WHERE clause only supports subquery with EXISTS clause")));
 				if (depth > 0)
 					ereport(ERROR,
 							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),

--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -2251,7 +2251,7 @@ rewrite_exists_subquery_walker(Query *query, Node *node, int *count)
 					ereport(ERROR,
 							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 							 errmsg("this query is not allowed on incrementally maintainable materialized view"),
-							 errhint("WHERE clause only support subquery with EXISTS clause")));
+							 errhint("subquery in WHERE clause only supports subquery with EXISTS clause")));
 
 				subselect = (Query *)sublink->subselect;
 				/* raise ERROR if it is CTE */

--- a/src/test/regress/expected/incremental_matview.out
+++ b/src/test/regress/expected/incremental_matview.out
@@ -5588,10 +5588,10 @@ ERROR:  system column is not supported on incrementally maintainable materialize
 -- targetlist or WHERE clause without EXISTS contain subquery
 CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm03 AS SELECT i,j FROM mv_base_a WHERE i IN (SELECT i FROM mv_base_b WHERE k < 103 );
 ERROR:  this query is not allowed on incrementally maintainable materialized view
-HINT:  WHERE clause only support subquery with EXISTS clause
+HINT:  subquery in WHERE clause only supports subquery with EXISTS clause
 CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm05 AS SELECT i,j, (SELECT k FROM mv_base_b b WHERE a.i = b.i) FROM mv_base_a a;
 ERROR:  this query is not allowed on incrementally maintainable materialized view
-HINT:  WHERE clause only support subquery with EXISTS clause
+HINT:  subquery in WHERE clause only supports subquery with EXISTS clause
 -- contain CTE
 CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm06 AS WITH b AS (SELECT i,k FROM mv_base_b WHERE k < 103) SELECT a.i,a.j FROM mv_base_a a,b WHERE a.i = b.i;
 ERROR:  CTE is not supported on incrementally maintainable materialized view


### PR DESCRIPTION
One error log when creating a immv has been corrected to a more
accurate representation.

This changes
```
ERROR: this query is not allowed on incrementally maintainable materialized view
HINT: WHERE clause only support subquery with EXISTS clause
```
to
```
ERROR: this query is not allowed on incrementally maintainable materialized view
HINT: subquery in WHERE clause only supports subquery with EXISTS clause
```

