### PR TITLE
Add comment for SetTransitionTablePreserved and related

### DIFF
--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -1386,7 +1386,7 @@ is_equijoin_condition(OpExpr *op)
 /*
  * check_aggregate_supports_ivm
  *
- * Check if the given aggregate function is supporting
+ * Check if the given aggregate function is supporting IVM
  */
 static bool
 check_aggregate_supports_ivm(Oid aggfnoid)

--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -1464,6 +1464,7 @@ IVM_immediate_maintenance(PG_FUNCTION_ARGS)
 		else
 			elog(ERROR,"unsupported trigger type");
 
+		/* Prolong lifespan of transition tables to the end of the last AFTER trigger */
 		SetTransitionTablePreserved(relid, cmd);
 	}
 


### PR DESCRIPTION
Also, remove the code which prolong transition tables automatically
for IVM triggers. This code is not necessary if we call the function
explicitly. This was left accidentally.

Although I am not sure if there is any use case of this function
other than IVM, I chose to use the function considering to avoid
to embed IVM specific code in trigger.c.

Per comments from Tatsuo Ishii in pgsql-hackers.