### PR TITLE
Fix an assertion error with LATERAL caluse

### DIFF
--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -1626,8 +1626,11 @@ IVM_immediate_maintenance(PG_FUNCTION_ARGS)
 					{
 						int attnum;
 						count_colname = getColumnNameStartWith(rte, "__ivm_exists", &attnum);
-						use_count = true;
-						in_exists = true;
+						if (count_colname)
+						{
+							use_count = true;
+							in_exists = true;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
When LATERAL was used, a subquery was regarded as one generated from
EXISTS clause even though this was ordinal subquery. This caused an
assertion error.

issue #107