### PR TITLE
Add support for simple CTEs

### DIFF
--- a/doc/src/sgml/ref/create_materialized_view.sgml
+++ b/doc/src/sgml/ref/create_materialized_view.sgml
@@ -210,6 +210,12 @@ a.i &gt; 5;
 
        <listitem>
         <para>
+         Simple CTEs which do not contain aggregates or DISTINCT.
+        </para>
+       </listitem>
+
+       <listitem>
+        <para>
          Some of aggregations (count, sum, avg, min, max) without HAVING
          clause.  However, aggregate functions in subquery is not supported:
          <programlisting>
@@ -235,7 +241,7 @@ a, (SELECT i, COUNT(*) FROM mv_base_b GROUP BY i) b WHERE a.i = b.i;
         </listitem>
        <listitem>
         <para>
-         CTE, WINDOW, LIMIT and OFFSET clause.
+         WINDOW, LIMIT and OFFSET clause.
         </para>
        </listitem>
       </itemizedlist>

--- a/doc/src/sgml/rules.sgml
+++ b/doc/src/sgml/rules.sgml
@@ -1377,7 +1377,7 @@ Time: 16386.245 ms (00:16.386)
 <title>Subqueries</title>
 <para>
     Currently, subqueries using <literal>EXISTS</literal> and simple
-     subqueries in <literal>FROM</literal> clause are supported.
+    subqueries in <literal>FROM</literal> clause are supported.
 </para>
 
     <sect4>
@@ -1445,13 +1445,41 @@ Time: 16386.245 ms (00:16.386)
 </sect3>
 
 <sect3>
+<title>CTEs</title>
+<para>
+    Currently, simple <literal>CTE</literal> in <literal>FROM</literal> clause are supported.
+</para>
+
+    <sect4>
+    <title>Restrictions on CTEs</title>
+    <para>
+        There are the following restrictions:
+    <itemizedlist>
+        <listitem>
+        <para>
+            Aggregate functions cannot be used in a CTE.
+        </para>
+        </listitem>
+
+        <listitem>
+        <para>
+            <literal>DISTINCT</literal> cannot be contained in a CTE.
+        </para>
+        </listitem>
+
+    </itemizedlist>
+    </para>
+    </sect4>
+</sect3>
+
+<sect3>
 <title>Other General Restrictions</title>
 <para>
     There are other restrictions which generally apply to <acronym>IMMV</acronym>:
     <itemizedlist>
         <listitem>
           <para>
-           <literal>CTE</literal> or window functions cannot be used.
+           window functions cannot be used.
           </para>
         </listitem>
 

--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -1045,7 +1045,7 @@ DefineIndex(Oid relationId,
 			if (attno > 0)
 			{
 				char *name = NameStr(TupleDescAttr(rel->rd_att, attno - 1)->attname);
-				if (name && isIvmColumn(name))
+				if (name && isIvmName(name))
 					ereport(ERROR,
 							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 							 errmsg("unique index creation on IVM columns is not supported")));
@@ -1063,7 +1063,7 @@ DefineIndex(Oid relationId,
 			{
 				int attno = varno + FirstLowInvalidHeapAttributeNumber;
 				char *name = NameStr(TupleDescAttr(rel->rd_att, attno - 1)->attname);
-				if (name && isIvmColumn(name))
+				if (name && isIvmName(name))
 					ereport(ERROR,
 							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 							 errmsg("unique index creation on IVM columns is not supported")));

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -3053,7 +3053,7 @@ renameatt_internal(Oid myrelid,
 	/*
 	 * Don't rename IVM columns.
 	 */
-	if (RelationIsIVM(targetrelation) && isIvmColumn(oldattname))
+	if (RelationIsIVM(targetrelation) && isIvmName(oldattname))
 		ereport(ERROR,
 				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 				 errmsg("IVM column can not be renamed")));

--- a/src/backend/optimizer/plan/subselect.c
+++ b/src/backend/optimizer/plan/subselect.c
@@ -87,7 +87,6 @@ static bool contain_dml(Node *node);
 static bool contain_dml_walker(Node *node, void *context);
 static bool contain_outer_selfref(Node *node);
 static bool contain_outer_selfref_walker(Node *node, Index *depth);
-static void inline_cte(PlannerInfo *root, CommonTableExpr *cte);
 static bool inline_cte_walker(Node *node, inline_cte_walker_context *context);
 static bool simplify_EXISTS_query(PlannerInfo *root, Query *query);
 static Query *convert_EXISTS_to_ANY(PlannerInfo *root, Query *subselect,
@@ -1085,7 +1084,7 @@ contain_outer_selfref_walker(Node *node, Index *depth)
 /*
  * inline_cte: convert RTE_CTE references to given CTE into RTE_SUBQUERYs
  */
-static void
+void
 inline_cte(PlannerInfo *root, CommonTableExpr *cte)
 {
 	struct inline_cte_walker_context context;

--- a/src/backend/parser/parse_relation.c
+++ b/src/backend/parser/parse_relation.c
@@ -2899,7 +2899,7 @@ expandTupleDesc(TupleDesc tupdesc, Alias *eref, int count, int offset,
 	{
 		Form_pg_attribute attr = TupleDescAttr(tupdesc, varattno);
 
-		if (is_ivm && isIvmColumn(NameStr(attr->attname)) && !MatViewIncrementalMaintenanceIsEnabled())
+		if (is_ivm && isIvmName(NameStr(attr->attname)) && !MatViewIncrementalMaintenanceIsEnabled())
 			continue;
 
 		if (attr->attisdropped)
@@ -3048,7 +3048,7 @@ expandNSItemAttrs(ParseState *pstate, ParseNamespaceItem *nsitem,
 		TargetEntry *te;
 
 		/* if transform * into columnlist with IMMV, remove IVM columns */
-		if (rte->relisivm && isIvmColumn(label) && !MatViewIncrementalMaintenanceIsEnabled())
+		if (rte->relisivm && isIvmName(label) && !MatViewIncrementalMaintenanceIsEnabled())
 			continue;
 
 		te = makeTargetEntry((Expr *) varnode,

--- a/src/include/commands/createas.h
+++ b/src/include/commands/createas.h
@@ -26,7 +26,7 @@ extern ObjectAddress ExecCreateTableAs(ParseState *pstate, CreateTableAsStmt *st
 									   ParamListInfo params, QueryEnvironment *queryEnv,
 									   QueryCompletion *qc);
 
-extern void CreateIvmTriggersOnBaseTables(Query *qry, Node *jtnode, Oid matviewOid, Relids *relids);
+extern void CreateIvmTriggersOnBaseTables(Query *qry, Node *node, Oid matviewOid, Relids *relids);
 
 extern Query *rewriteQueryForIMMV(Query *query, List *colNames);
 

--- a/src/include/commands/matview.h
+++ b/src/include/commands/matview.h
@@ -38,6 +38,6 @@ extern Datum IVM_immediate_maintenance(PG_FUNCTION_ARGS);
 extern Query* rewrite_query_for_exists_subquery(Query *query);
 extern void AtAbort_IVM(void);
 extern char *getColumnNameStartWith(RangeTblEntry *rte, char *str, int *attnum);
-extern bool isIvmColumn(const char *s);
+extern bool isIvmName(const char *s);
 
 #endif							/* MATVIEW_H */

--- a/src/include/optimizer/optimizer.h
+++ b/src/include/optimizer/optimizer.h
@@ -121,6 +121,11 @@ extern void extract_query_dependencies(Node *query,
 									   List **invalItems,
 									   bool *hasRowSecurity);
 
+/* in plan/subselect.c: */
+
+extern void
+inline_cte(PlannerInfo *root, CommonTableExpr *cte);
+
 /* in prep/prepqual.c: */
 
 extern Node *negate_clause(Node *node);
@@ -186,5 +191,6 @@ extern bool contain_vars_of_level(Node *node, int levelsup);
 extern int	locate_var_of_level(Node *node, int levelsup);
 extern List *pull_var_clause(Node *node, int flags);
 extern Node *flatten_join_alias_vars(Query *query, Node *node);
+
 
 #endif							/* OPTIMIZER_H */

--- a/src/test/regress/expected/incremental_matview.out
+++ b/src/test/regress/expected/incremental_matview.out
@@ -636,6 +636,100 @@ SELECT * FROM mv_ivm_join_subquery ORDER BY i,j,k;
 (8 rows)
 
 ROLLBACK;
+-- support simple CTE
+BEGIN;
+CREATE INCREMENTAL MATERIALIZED VIEW mv_cte AS
+    WITH b AS ( SELECT * FROM mv_base_b) SELECT a.i,a.j FROM mv_base_a a, b WHERE a.i = b.i;
+INSERT INTO mv_base_a VALUES(2,20);
+INSERT INTO mv_base_b VALUES(3,300);
+SELECT * FROM mv_cte ORDER BY i,j;
+ i | j  
+---+----
+ 1 | 10
+ 2 | 20
+ 2 | 20
+ 3 | 30
+ 3 | 30
+ 4 | 40
+(6 rows)
+
+ROLLBACK;
+BEGIN;
+CREATE INCREMENTAL MATERIALIZED VIEW mv_cte AS
+    WITH a AS (SELECT * FROM mv_base_a), b AS ( SELECT * FROM mv_base_b) SELECT a.i,a.j FROM a, b WHERE a.i = b.i;
+INSERT INTO mv_base_a VALUES(2,20);
+INSERT INTO mv_base_b VALUES(3,300);
+SELECT * FROM mv_cte ORDER BY i,j;
+ i | j  
+---+----
+ 1 | 10
+ 2 | 20
+ 2 | 20
+ 3 | 30
+ 3 | 30
+ 4 | 40
+(6 rows)
+
+ROLLBACK;
+BEGIN;
+CREATE INCREMENTAL MATERIALIZED VIEW mv_cte AS
+    WITH b AS ( SELECT * FROM mv_base_b) SELECT v.i,v.j FROM (WITH a AS (SELECT * FROM mv_base_a) SELECT a.i,a.j FROM a, b WHERE a.i = b.i) v;
+INSERT INTO mv_base_a VALUES(2,20);
+INSERT INTO mv_base_b VALUES(3,300);
+SELECT * FROM mv_cte ORDER BY i,j;
+ i | j  
+---+----
+ 1 | 10
+ 2 | 20
+ 2 | 20
+ 3 | 30
+ 3 | 30
+ 4 | 40
+(6 rows)
+
+ROLLBACK;
+BEGIN;
+CREATE INCREMENTAL MATERIALIZED VIEW mv_cte AS
+    SELECT * FROM (WITH a AS (SELECT * FROM mv_base_a), b AS ( SELECT * FROM mv_base_b) SELECT a.i,a.j FROM a, b WHERE a.i = b.i) v;
+INSERT INTO mv_base_a VALUES(2,20);
+INSERT INTO mv_base_b VALUES(3,300);
+SELECT * FROM mv_cte ORDER BY i,j;
+ i | j  
+---+----
+ 1 | 10
+ 2 | 20
+ 2 | 20
+ 3 | 30
+ 3 | 30
+ 4 | 40
+(6 rows)
+
+ROLLBACK;
+BEGIN;
+CREATE INCREMENTAL MATERIALIZED VIEW mv_cte AS
+    WITH x AS ( SELECT i, a.j, b.k FROM mv_base_b b INNER JOIN mv_base_a a USING(i)) SELECT * FROM x;
+WITH
+ ai AS (INSERT INTO mv_base_a VALUES (1,11),(2,22) RETURNING 0),
+ bi AS (INSERT INTO mv_base_b VALUES (1,111),(3,133) RETURNING 0),
+ bd AS (DELETE FROM mv_base_b WHERE i = 4 RETURNING 0)
+SELECT;
+--
+(1 row)
+
+SELECT * FROM mv_cte ORDER BY i,j,k;
+ i | j  |  k  
+---+----+-----
+ 1 | 10 | 101
+ 1 | 10 | 111
+ 1 | 11 | 101
+ 1 | 11 | 111
+ 2 | 20 | 102
+ 2 | 22 | 102
+ 3 | 30 | 103
+ 3 | 30 | 133
+(8 rows)
+
+ROLLBACK;
 -- views including NULL
 BEGIN;
 CREATE TABLE base_t (i int, v int);
@@ -5576,7 +5670,7 @@ HINT:  aggregate is not supported with outer join
 -- subquery is not supported with outer join
 CREATE INCREMENTAL MATERIALIZED VIEW mv(a,b) AS SELECT a.i, b.i FROM mv_base_a a LEFT JOIN (SELECT * FROM mv_base_b) b ON a.i=b.i;
 ERROR:  this query is not allowed on incrementally maintainable materialized view
-HINT:  subquery is not supported with outer join
+HINT:  subquery or CTE is not supported with outer join
 CREATE INCREMENTAL MATERIALIZED VIEW mv(a,b) AS SELECT a.i, b.i FROM mv_base_a a LEFT JOIN mv_base_b b ON a.i=b.i WHERE EXISTS (SELECT 1 FROM mv_base_b b2 WHERE a.j = b.k);
 ERROR:  this query is not allowed on incrementally maintainable materialized view
 HINT:  subquery with outer join is not supported
@@ -5592,9 +5686,6 @@ HINT:  subquery in WHERE clause only supports subquery with EXISTS clause
 CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm05 AS SELECT i,j, (SELECT k FROM mv_base_b b WHERE a.i = b.i) FROM mv_base_a a;
 ERROR:  this query is not allowed on incrementally maintainable materialized view
 HINT:  subquery in WHERE clause only supports subquery with EXISTS clause
--- contain CTE
-CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm06 AS WITH b AS (SELECT i,k FROM mv_base_b WHERE k < 103) SELECT a.i,a.j FROM mv_base_a a,b WHERE a.i = b.i;
-ERROR:  CTE is not supported on incrementally maintainable materialized view
 -- contain ORDER BY
 CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm07 AS SELECT i,j,k FROM mv_base_a a INNER JOIN mv_base_b b USING(i) ORDER BY i,j,k;
 ERROR:  ORDER BY clause is not supported on incrementally maintainable materialized view


### PR DESCRIPTION
Simple CTEs which does not contain aggregates or DISTINCT are now
supported similarly to simple sub-queries.

Before a view is maintained, all CTEs are converted to corresponding
subqueries to enable to treat CTEs as same as subqueries. For this
end, inline_cte in optimizer/plan/subselect.c was export to public.

Related issue #8