### PR TITLE
Prohibit VALUES clause in IMMV

### DIFF
--- a/doc/src/sgml/ref/create_materialized_view.sgml
+++ b/doc/src/sgml/ref/create_materialized_view.sgml
@@ -241,7 +241,7 @@ a, (SELECT i, COUNT(*) FROM mv_base_b GROUP BY i) b WHERE a.i = b.i;
         </listitem>
        <listitem>
         <para>
-         WINDOW, LIMIT and OFFSET clause.
+         DISTINCT ON, WINDOW, VALUES, LIMIT and OFFSET clause.
         </para>
        </listitem>
       </itemizedlist>

--- a/doc/src/sgml/rules.sgml
+++ b/doc/src/sgml/rules.sgml
@@ -1535,6 +1535,12 @@ Time: 16386.245 ms (00:16.386)
 
         <listitem>
           <para>
+            VALUES clause cannnot be used.
+          </para>
+        </listitem>
+
+        <listitem>
+          <para>
             <literal>GROUPING SETS</literal> and <literal>FILTER</literal> clauses cannot be used.
           </para>
         </listitem>

--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -1126,6 +1126,11 @@ check_ivm_restriction_walker(Node *node, check_ivm_restriction_context *ctx, int
 								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 								 errmsg("VIEW or MATERIALIZED VIEW is not supported on incrementally maintainable materialized view")));
 
+					if (rte->rtekind ==  RTE_VALUES)
+						ereport(ERROR,
+								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+								 errmsg("VALUES is not supported on incrementally maintainable materialized view")));
+
 					if (rte->rtekind ==  RTE_SUBQUERY)
 					{
 						if (ctx->has_outerjoin)

--- a/src/test/regress/expected/incremental_matview.out
+++ b/src/test/regress/expected/incremental_matview.out
@@ -90,8 +90,6 @@ CREATE FUNCTION ivm_func() RETURNS int LANGUAGE 'sql'
        AS 'SELECT 1' IMMUTABLE;
 CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_func AS SELECT * FROM ivm_func();
 CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_no_tbl AS SELECT 1;
-CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_only_values1 AS values(1);
-CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_only_values2 AS SELECT * FROM (values(1)) AS tmp;
 ROLLBACK;
 -- result of materliazied view have DISTINCT clause or the duplicate result.
 BEGIN;
@@ -5763,6 +5761,11 @@ CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm30 AS SELECT sum(i)*0.5 FROM mv_base_
 ERROR:  expression containing an aggregate in it is not supported on incrementally maintainable materialized view
 CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm31 AS SELECT sum(i)/sum(j) FROM mv_base_a;
 ERROR:  expression containing an aggregate in it is not supported on incrementally maintainable materialized view
+-- VALUES is not supported
+CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_only_values1 AS values(1);
+ERROR:  VALUES is not supported on incrementally maintainable materialized view
+CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_only_values2 AS SELECT * FROM (values(1)) AS tmp;
+ERROR:  VALUES is not supported on incrementally maintainable materialized view
 -- base table which has row level security
 DROP USER IF EXISTS ivm_admin;
 NOTICE:  role "ivm_admin" does not exist, skipping

--- a/src/test/regress/sql/incremental_matview.sql
+++ b/src/test/regress/sql/incremental_matview.sql
@@ -46,8 +46,6 @@ CREATE FUNCTION ivm_func() RETURNS int LANGUAGE 'sql'
        AS 'SELECT 1' IMMUTABLE;
 CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_func AS SELECT * FROM ivm_func();
 CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_no_tbl AS SELECT 1;
-CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_only_values1 AS values(1);
-CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_only_values2 AS SELECT * FROM (values(1)) AS tmp;
 ROLLBACK;
 
 -- result of materliazied view have DISTINCT clause or the duplicate result.
@@ -1702,6 +1700,10 @@ CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm29 AS SELECT COUNT(i) FROM mv_base_a
 -- experssions containing an aggregate is not supported
 CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm30 AS SELECT sum(i)*0.5 FROM mv_base_a;
 CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm31 AS SELECT sum(i)/sum(j) FROM mv_base_a;
+
+-- VALUES is not supported
+CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_only_values1 AS values(1);
+CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_only_values2 AS SELECT * FROM (values(1)) AS tmp;
 
 -- base table which has row level security
 DROP USER IF EXISTS ivm_admin;


### PR DESCRIPTION
Currently, VALUES is prohibited only for simplicity.
If users want to support this, it would be possible.

issue #110