### PR TITLE
fix restriction of EXISTS subquery

### DIFF
--- a/src/test/regress/expected/incremental_matview.out
+++ b/src/test/regress/expected/incremental_matview.out
@@ -5766,6 +5766,10 @@ CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_only_values1 AS values(1);
 ERROR:  VALUES is not supported on incrementally maintainable materialized view
 CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_only_values2 AS SELECT * FROM (values(1)) AS tmp;
 ERROR:  VALUES is not supported on incrementally maintainable materialized view
+-- column of parent query specified in EXISTS clause must appear in the target list.
+CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm32 AS SELECT a.j FROM mv_base_a a WHERE EXISTS(SELECT 1 FROM mv_base_b b WHERE a.i = b.i);
+ERROR:  this query is not allowed on incrementally maintainable materialized view
+HINT:  targetlist must contain vars what is reffered by subquery
 -- base table which has row level security
 DROP USER IF EXISTS ivm_admin;
 NOTICE:  role "ivm_admin" does not exist, skipping

--- a/src/test/regress/expected/incremental_matview.out
+++ b/src/test/regress/expected/incremental_matview.out
@@ -5769,7 +5769,7 @@ ERROR:  VALUES is not supported on incrementally maintainable materialized view
 -- column of parent query specified in EXISTS clause must appear in the target list.
 CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm32 AS SELECT a.j FROM mv_base_a a WHERE EXISTS(SELECT 1 FROM mv_base_b b WHERE a.i = b.i);
 ERROR:  this query is not allowed on incrementally maintainable materialized view
-HINT:  targetlist must contain vars what is reffered by subquery
+HINT:  targetlist must contain vars that are refered to in EXISTS subquery
 -- base table which has row level security
 DROP USER IF EXISTS ivm_admin;
 NOTICE:  role "ivm_admin" does not exist, skipping

--- a/src/test/regress/sql/incremental_matview.sql
+++ b/src/test/regress/sql/incremental_matview.sql
@@ -1705,6 +1705,9 @@ CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm31 AS SELECT sum(i)/sum(j) FROM mv_ba
 CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_only_values1 AS values(1);
 CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_only_values2 AS SELECT * FROM (values(1)) AS tmp;
 
+-- column of parent query specified in EXISTS clause must appear in the target list.
+CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm32 AS SELECT a.j FROM mv_base_a a WHERE EXISTS(SELECT 1 FROM mv_base_b b WHERE a.i = b.i);
+
 -- base table which has row level security
 DROP USER IF EXISTS ivm_admin;
 DROP USER IF EXISTS ivm_user;


### PR DESCRIPTION
The targetlist must need parent tables column which is contained by
exists join condition, to use IVM EXISTS clause.

This restriction will add this fix.
In the future, supporting multi-stage subqueries will require more
complex processing.

This problem is reported by issues #109 .