### PR TITLE
Use weaker lock on matview if possible

### DIFF
--- a/doc/src/sgml/rules.sgml
+++ b/doc/src/sgml/rules.sgml
@@ -1652,6 +1652,8 @@ Time: 16386.245 ms (00:16.386)
     if lock acquisition fails because any changes which occurred in
     other transactions are not be visible in these modes and
     <acronym>IMMV</acronym> cannot be updated correctly in such situations.
+    However, as an exception if the view has only one base table, 
+    the lock held on thew view is <literal>RowExclusiveLock</literal>.
 </para>
 </sect2>
 


### PR DESCRIPTION
If the view has only one base table in this query, we can use
RowExclusiveLock instead of AccessExclusiveLock, because we don't
need to wait other concurrent transaction's result in order to
maintain the view in this case. When the same row in the view is
affected due to concurrent maintenances, a row level lock will
protect it.