### PR TITLE
Reduce probbility of deadlock

### DIFF
--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -101,7 +101,8 @@ static bool intorel_receive(TupleTableSlot *slot, DestReceiver *self);
 static void intorel_shutdown(DestReceiver *self);
 static void intorel_destroy(DestReceiver *self);
 
-static void CreateIvmTrigger(Oid relOid, Oid viewOid, int16 type, int16 timing);
+static void CreateIvmTriggersOnBaseTables_recurse(Query *qry, Node *node, Oid matviewOid, Relids *relids, bool ex_lock);
+static void CreateIvmTrigger(Oid relOid, Oid viewOid, int16 type, int16 timing, bool ex_lock);
 static void check_ivm_restriction_walker(Node *node, check_ivm_restriction_context *ctx, int depth);
 static void CreateIndexOnIMMV(Query *query, Relation matviewRel);
 static Bitmapset *get_primary_key_attnos_from_query(Query *qry, List **constraintList);
@@ -422,7 +423,6 @@ ExecCreateTableAs(ParseState *pstate, CreateTableAsStmt *stmt,
 		{
 			Oid matviewOid = address.objectId;
 			Relation matviewRel = table_open(matviewOid, NoLock);
-			Relids	relids = NULL;
 
 			/*
 			 * Mark relisivm field, if it's a matview and into->ivm is true.
@@ -436,8 +436,7 @@ ExecCreateTableAs(ParseState *pstate, CreateTableAsStmt *stmt,
 			if (!into->skipData)
 			{
 				Assert(query_immv != NULL);
-				CreateIvmTriggersOnBaseTables(query_immv, (Node *)query_immv, matviewOid, &relids);
-				bms_free(relids);
+				CreateIvmTriggersOnBaseTables(query_immv, matviewOid);
 			}
 			table_close(matviewRel, NoLock);
 		}
@@ -630,72 +629,6 @@ rewriteQueryForIMMV(Query *query, List *colNames)
 	return rewritten;
 }
 
-/*
- * CreateIvmTriggersOnBaseTables -- create IVM triggers on all base tables
- */
-void
-CreateIvmTriggersOnBaseTables(Query *qry, Node *node, Oid matviewOid, Relids *relids)
-{
-	if (node == NULL)
-		return;
-	if (IsA(node, Query))
-	{
-		Query *query = (Query *) node;
-		ListCell *lc;
-
-		CreateIvmTriggersOnBaseTables(qry, (Node *)query->jointree, matviewOid, relids);
-		foreach(lc, query->cteList)
-		{
-			CommonTableExpr *cte = (CommonTableExpr *) lfirst(lc);
-			Assert(IsA(cte->ctequery, Query));
-			CreateIvmTriggersOnBaseTables((Query *) cte->ctequery, cte->ctequery, matviewOid, relids);
-		}
-	}
-	else if (IsA(node, RangeTblRef))
-	{
-		int			rti = ((RangeTblRef *) node)->rtindex;
-		RangeTblEntry *rte = rt_fetch(rti, qry->rtable);
-
-		if (rte->rtekind == RTE_RELATION)
-		{
-			if (!bms_is_member(rte->relid, *relids))
-			{
-				CreateIvmTrigger(rte->relid, matviewOid, TRIGGER_TYPE_INSERT, TRIGGER_TYPE_BEFORE);
-				CreateIvmTrigger(rte->relid, matviewOid, TRIGGER_TYPE_DELETE, TRIGGER_TYPE_BEFORE);
-				CreateIvmTrigger(rte->relid, matviewOid, TRIGGER_TYPE_UPDATE, TRIGGER_TYPE_BEFORE);
-				CreateIvmTrigger(rte->relid, matviewOid, TRIGGER_TYPE_INSERT, TRIGGER_TYPE_AFTER);
-				CreateIvmTrigger(rte->relid, matviewOid, TRIGGER_TYPE_DELETE, TRIGGER_TYPE_AFTER);
-				CreateIvmTrigger(rte->relid, matviewOid, TRIGGER_TYPE_UPDATE, TRIGGER_TYPE_AFTER);
-
-				*relids = bms_add_member(*relids, rte->relid);
-			}
-		}
-		else if (rte->rtekind == RTE_SUBQUERY)
-		{
-			Query *subquery = rte->subquery;
-			Assert(rte->subquery != NULL);
-
-			CreateIvmTriggersOnBaseTables(subquery, (Node *)subquery, matviewOid, relids);
-		}
-	}
-	else if (IsA(node, FromExpr))
-	{
-		FromExpr   *f = (FromExpr *) node;
-		ListCell   *l;
-
-		foreach(l, f->fromlist)
-			CreateIvmTriggersOnBaseTables(qry, lfirst(l), matviewOid, relids);
-	}
-	else if (IsA(node, JoinExpr))
-	{
-		JoinExpr   *j = (JoinExpr *) node;
-
-		CreateIvmTriggersOnBaseTables(qry, j->larg, matviewOid, relids);
-		CreateIvmTriggersOnBaseTables(qry, j->rarg, matviewOid, relids);
-	}
-	else
-		elog(ERROR, "unrecognized node type: %d", (int) nodeTag(node));
-}
 
 /*
  * GetIntoRelEFlags --- compute executor flags needed for CREATE TABLE AS
@@ -959,10 +892,120 @@ intorel_destroy(DestReceiver *self)
 }
 
 /*
+ * CreateIvmTriggersOnBaseTables -- create IVM triggers on all base tables
+ */
+void
+CreateIvmTriggersOnBaseTables(Query *qry, Oid matviewOid)
+{
+	Relids	relids = NULL;
+	bool	ex_lock = false;
+	RangeTblEntry *rte = list_nth(qry->rtable, PRS2_NEW_VARNO);
+
+	/*
+	 * If the view has more than one base tables, we need an exclusive lock
+	 * on the view so that the view would be maintained serially to avoid
+	 * the inconsistency that occurs when two base tables are modified in
+	 * concurrent transactions. However, if the view has only one table,
+	 * we can use a weaker lock.
+	 *
+	 * The type of lock should be determined here, because if we check the
+	 * view definition at maintenance time, we need to acquire a weaker lock,
+	 * and upgrading the lock level after this increases probability of
+	 * deadlock.
+	 */
+	if (list_length(qry->rtable) > PRS2_NEW_VARNO + 1 ||
+		rte->rtekind != RTE_RELATION)
+		ex_lock = true;
+
+	CreateIvmTriggersOnBaseTables_recurse(qry, (Node *)qry, matviewOid, &relids, ex_lock);
+
+	bms_free(relids);
+}
+
+static void
+CreateIvmTriggersOnBaseTables_recurse(Query *qry, Node *node, Oid matviewOid, Relids *relids, bool ex_lock)
+{
+	/* This can recurse, so check for excessive recursion */
+	check_stack_depth();
+
+	if (node == NULL)
+		return;
+
+	switch (nodeTag(node))
+	{
+		case T_Query:
+			{
+				Query *query = (Query *) node;
+				ListCell *lc;
+
+				CreateIvmTriggersOnBaseTables_recurse(qry, (Node *)query->jointree, matviewOid, relids, ex_lock);
+				foreach(lc, query->cteList)
+				{
+					CommonTableExpr *cte = (CommonTableExpr *) lfirst(lc);
+					Assert(IsA(cte->ctequery, Query));
+					CreateIvmTriggersOnBaseTables_recurse((Query *) cte->ctequery, cte->ctequery, matviewOid, relids, ex_lock);
+				}
+			}
+			break;
+
+		case T_RangeTblRef:
+			{
+				int			rti = ((RangeTblRef *) node)->rtindex;
+				RangeTblEntry *rte = rt_fetch(rti, qry->rtable);
+
+				if (rte->rtekind == RTE_RELATION)
+				{
+					if (!bms_is_member(rte->relid, *relids))
+					{
+						CreateIvmTrigger(rte->relid, matviewOid, TRIGGER_TYPE_INSERT, TRIGGER_TYPE_BEFORE, ex_lock);
+						CreateIvmTrigger(rte->relid, matviewOid, TRIGGER_TYPE_DELETE, TRIGGER_TYPE_BEFORE, ex_lock);
+						CreateIvmTrigger(rte->relid, matviewOid, TRIGGER_TYPE_UPDATE, TRIGGER_TYPE_BEFORE, ex_lock);
+						CreateIvmTrigger(rte->relid, matviewOid, TRIGGER_TYPE_INSERT, TRIGGER_TYPE_AFTER, ex_lock);
+						CreateIvmTrigger(rte->relid, matviewOid, TRIGGER_TYPE_DELETE, TRIGGER_TYPE_AFTER, ex_lock);
+						CreateIvmTrigger(rte->relid, matviewOid, TRIGGER_TYPE_UPDATE, TRIGGER_TYPE_AFTER, ex_lock);
+
+						*relids = bms_add_member(*relids, rte->relid);
+					}
+				}
+				else if (rte->rtekind == RTE_SUBQUERY)
+				{
+					Query *subquery = rte->subquery;
+					Assert(rte->subquery != NULL);
+
+					CreateIvmTriggersOnBaseTables_recurse(subquery, (Node *)subquery, matviewOid, relids, ex_lock);
+				}
+			}
+			break;
+
+		case T_FromExpr:
+			{
+				FromExpr   *f = (FromExpr *) node;
+				ListCell   *l;
+
+				foreach(l, f->fromlist)
+					CreateIvmTriggersOnBaseTables_recurse(qry, lfirst(l), matviewOid, relids, ex_lock);
+			}
+			break;
+
+		case T_JoinExpr:
+			{
+				JoinExpr   *j = (JoinExpr *) node;
+
+				CreateIvmTriggersOnBaseTables_recurse(qry, j->larg, matviewOid, relids, ex_lock);
+				CreateIvmTriggersOnBaseTables_recurse(qry, j->rarg, matviewOid, relids, ex_lock);
+			}
+			break;
+
+		default:
+			elog(ERROR, "unrecognized node type: %d", (int) nodeTag(node));
+	}
+}
+
+/*
  * CreateIvmTrigger -- create IVM trigger on a base table
  */
 static void
-CreateIvmTrigger(Oid relOid, Oid viewOid, int16 type, int16 timing)
+CreateIvmTrigger(Oid relOid, Oid viewOid, int16 type, int16 timing, bool ex_lock)
 {
 	ObjectAddress	refaddr;
 	ObjectAddress	address;
@@ -1029,8 +1072,10 @@ CreateIvmTrigger(Oid relOid, Oid viewOid, int16 type, int16 timing)
 	ivm_trigger->deferrable = false;
 	ivm_trigger->initdeferred = false;
 	ivm_trigger->constrrel = NULL;
-	ivm_trigger->args = list_make1(makeString(
-		DatumGetPointer(DirectFunctionCall1(oidout, ObjectIdGetDatum(viewOid)))));
+	ivm_trigger->args = list_make2(
+		makeString(DatumGetPointer(DirectFunctionCall1(oidout, ObjectIdGetDatum(viewOid)))),
+		makeString(DatumGetPointer(DirectFunctionCall1(boolout, BoolGetDatum(ex_lock))))
+		);
 
 	address = CreateTrigger(ivm_trigger, NULL, relOid, InvalidOid, InvalidOid,
 						 InvalidOid, InvalidOid, InvalidOid, NULL, true, false);

--- a/src/backend/commands/matview.c
+++ b/src/backend/commands/matview.c
@@ -634,7 +634,7 @@ ExecRefreshMatView(RefreshMatViewStmt *stmt, const char *queryString,
 	}
 
 	if (!stmt->skipData && RelationIsIVM(matviewRel) && !oldPopulated)
-		CreateIvmTriggersOnBaseTables(dataQuery, matviewOid);
+		CreateIvmTriggersOnBaseTables(dataQuery, matviewOid, false);
 
 	table_close(matviewRel, NoLock);
 

--- a/src/include/commands/createas.h
+++ b/src/include/commands/createas.h
@@ -26,7 +26,7 @@ extern ObjectAddress ExecCreateTableAs(ParseState *pstate, CreateTableAsStmt *st
 									   ParamListInfo params, QueryEnvironment *queryEnv,
 									   QueryCompletion *qc);
 
-extern void CreateIvmTriggersOnBaseTables(Query *qry, Oid matviewOid);
+extern void CreateIvmTriggersOnBaseTables(Query *qry, Oid matviewOid, bool is_create);
 
 extern Query *rewriteQueryForIMMV(Query *query, List *colNames);
 

--- a/src/include/commands/createas.h
+++ b/src/include/commands/createas.h
@@ -26,7 +26,7 @@ extern ObjectAddress ExecCreateTableAs(ParseState *pstate, CreateTableAsStmt *st
 									   ParamListInfo params, QueryEnvironment *queryEnv,
 									   QueryCompletion *qc);
 
-extern void CreateIvmTriggersOnBaseTables(Query *qry, Node *node, Oid matviewOid, Relids *relids);
+extern void CreateIvmTriggersOnBaseTables(Query *qry, Oid matviewOid);
 
 extern Query *rewriteQueryForIMMV(Query *query, List *colNames);
 


### PR DESCRIPTION
If the view has more than one base tables, we need an exclusive lock
on the view so that the view would be maintained serially to avoid
the inconsistency that occurs when two base tables are modified in
concurrent transactions. However, if the view has only one table,
we can use a weaker lock.

Previously, we checked the view definition at maintenance time to
determin the lock strength. However, this caused high probability
of dead-lock, because we needed to upgrade the lock level after
the weeker lock acquired to get the view definition.

Now, the lock type is determined at view definition, and passed
via an argument of the trigger function to avoid the lock level
upgrading.