### PR TITLE
Fix restriction worker

### DIFF
--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -1114,7 +1114,6 @@ CreateIvmTrigger(Oid relOid, Oid viewOid, int16 type, int16 timing, bool ex_lock
 static void
 check_ivm_restriction(Node *node, check_ivm_restriction_context *context)
 {
-	//check_ivm_restriction_context *context;
 	check_ivm_restriction_walker(node, context);
 }
 
@@ -1238,7 +1237,7 @@ check_ivm_restriction_walker(Node *node, check_ivm_restriction_context *ctx)
 						ctx->has_subquery = true;
 
 						ctx->sublevels_up++;
-						check_ivm_restriction_walker(rte->subquery, ctx);
+						check_ivm_restriction_walker((Node *)rte->subquery, ctx);
 						ctx->sublevels_up--;
 					}
 				}
@@ -1456,24 +1455,8 @@ check_ivm_restriction_walker(Node *node, check_ivm_restriction_context *ctx)
 							 errmsg("aggregate function %s is not supported on incrementally maintainable materialized view", aggname)));
 				break;
 			}
-		case T_FromExpr:
-		case T_NullIfExpr: /* same as OpExpr */
-		case T_DistinctExpr: /* same as OpExpr */
-		case T_OpExpr:
-		case T_BoolExpr:
-		case T_CaseExpr:
-		case T_SubPlan:
-		case T_GroupingFunc:
-		case T_WindowFunc:
-		case T_FuncExpr:
-		case T_CoerceViaIO:
-		case T_List:
-			{
-				expression_tree_walker(node, check_ivm_restriction_walker, ctx);
-				break;
-			}
 		default:
-			/* do nothing */
+			expression_tree_walker(node, check_ivm_restriction_walker, ctx);
 			break;
 	}
 	return false;

--- a/src/test/regress/expected/incremental_matview.out
+++ b/src/test/regress/expected/incremental_matview.out
@@ -5769,6 +5769,10 @@ CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm01 AS SELECT i,j,xmin FROM mv_base_a
 ERROR:  system column is not supported on incrementally maintainable materialized view
 CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm02 AS SELECT i,j FROM mv_base_a WHERE xmin = '610';
 ERROR:  system column is not supported on incrementally maintainable materialized view
+CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm04 AS SELECT i,j,xmin::text AS x_min FROM mv_base_a;
+ERROR:  system column is not supported on incrementally maintainable materialized view
+CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm06 AS SELECT i,j,xidsend(xmin) AS x_min FROM mv_base_a;
+ERROR:  system column is not supported on incrementally maintainable materialized view
 -- targetlist or WHERE clause without EXISTS contain subquery
 CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm03 AS SELECT i,j FROM mv_base_a WHERE i IN (SELECT i FROM mv_base_b WHERE k < 103 );
 ERROR:  this query is not allowed on incrementally maintainable materialized view

--- a/src/test/regress/sql/incremental_matview.sql
+++ b/src/test/regress/sql/incremental_matview.sql
@@ -1633,6 +1633,8 @@ CREATE INCREMENTAL MATERIALIZED VIEW mv(a,b) AS SELECT a.i, b.i FROM mv_base_a a
 -- contain system column
 CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm01 AS SELECT i,j,xmin FROM mv_base_a;
 CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm02 AS SELECT i,j FROM mv_base_a WHERE xmin = '610';
+CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm04 AS SELECT i,j,xmin::text AS x_min FROM mv_base_a;
+CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm06 AS SELECT i,j,xidsend(xmin) AS x_min FROM mv_base_a;
 -- targetlist or WHERE clause without EXISTS contain subquery
 CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm03 AS SELECT i,j FROM mv_base_a WHERE i IN (SELECT i FROM mv_base_b WHERE k < 103 );
 CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm05 AS SELECT i,j, (SELECT k FROM mv_base_b b WHERE a.i = b.i) FROM mv_base_a a;


### PR DESCRIPTION
IVM's restriction was checked by an unique worker function. But it had some miss check.
This fix  changes it to common function such as query_tree_walker() and expression_tree_walker(). 