### PR TITLE
Fix segment fault by subquery in targetlist

### DIFF
--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -1393,6 +1393,11 @@ check_ivm_restriction_walker(Node *node, check_ivm_restriction_context *context)
 					ereport(ERROR,
 							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 							 errmsg("expression containing an aggregate in it is not supported on incrementally maintainable materialized view")));
+				if (IsA(tle->expr, SubLink))
+					ereport(ERROR,
+							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+							 errmsg("this query is not allowed on incrementally maintainable materialized view"),
+							 errhint("subquery is not supported in targetlist")));
 
 				expression_tree_walker(node, check_ivm_restriction_walker, (void *) context);
 				break;

--- a/src/test/regress/expected/incremental_matview.out
+++ b/src/test/regress/expected/incremental_matview.out
@@ -5819,7 +5819,7 @@ ERROR:  this query is not allowed on incrementally maintainable materialized vie
 HINT:  subquery in WHERE clause only supports subquery with EXISTS clause
 CREATE INCREMENTAL MATERIALIZED VIEW  mv_ivm05 AS SELECT i,j, (SELECT k FROM mv_base_b b WHERE a.i = b.i) FROM mv_base_a a;
 ERROR:  this query is not allowed on incrementally maintainable materialized view
-HINT:  subquery in WHERE clause only supports subquery with EXISTS clause
+HINT:  subquery is not supported in targetlist
 -- contain ORDER BY
 CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm07 AS SELECT i,j,k FROM mv_base_a a INNER JOIN mv_base_b b USING(i) ORDER BY i,j,k;
 ERROR:  ORDER BY clause is not supported on incrementally maintainable materialized view


### PR DESCRIPTION
If contain subquery with EXISTS clause in target list, segfault happen.

This issue is reported by issue #134.