### PR TITLE
remove deptype 'm' in pg_depend

### DIFF
--- a/src/backend/catalog/dependency.c
+++ b/src/backend/catalog/dependency.c
@@ -598,7 +598,6 @@ findDependentObjects(const ObjectAddress *object,
 			case DEPENDENCY_NORMAL:
 			case DEPENDENCY_AUTO:
 			case DEPENDENCY_AUTO_EXTENSION:
-			case DEPENDENCY_IMMV:
 				/* no problem */
 				break;
 
@@ -916,7 +915,6 @@ findDependentObjects(const ObjectAddress *object,
 				subflags = DEPFLAG_AUTO;
 				break;
 			case DEPENDENCY_INTERNAL:
-			case DEPENDENCY_IMMV:
 				subflags = DEPFLAG_INTERNAL;
 				break;
 			case DEPENDENCY_PARTITION_PRI:

--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -1105,7 +1105,7 @@ CreateIvmTrigger(Oid relOid, Oid viewOid, int16 type, int16 timing, bool ex_lock
 	address = CreateTrigger(ivm_trigger, NULL, relOid, InvalidOid, InvalidOid,
 						 InvalidOid, InvalidOid, InvalidOid, NULL, true, false);
 
-	recordDependencyOn(&address, &refaddr, DEPENDENCY_IMMV);
+	recordDependencyOn(&address, &refaddr, DEPENDENCY_AUTO);
 
 	/* Make changes-so-far visible */
 	CommandCounterIncrement();

--- a/src/include/catalog/dependency.h
+++ b/src/include/catalog/dependency.h
@@ -37,7 +37,6 @@ typedef enum DependencyType
 	DEPENDENCY_PARTITION_SEC = 'S',
 	DEPENDENCY_EXTENSION = 'e',
 	DEPENDENCY_AUTO_EXTENSION = 'x',
-	DEPENDENCY_IMMV = 'm'
 } DependencyType;
 
 /*

--- a/src/test/regress/expected/incremental_matview.out
+++ b/src/test/regress/expected/incremental_matview.out
@@ -29,6 +29,34 @@ SELECT * FROM mv_ivm_1 ORDER BY 1,2,3;
  4 | 40 | 104
 (4 rows)
 
+-- REFRESH WITH NO DATA
+BEGIN;
+CREATE FUNCTION dummy_ivm_trigger_func() RETURNS TRIGGER AS $$
+  BEGIN
+    RETURN NULL;
+  END
+$$ language plpgsql;
+CREATE CONSTRAINT TRIGGER dummy_ivm_trigger AFTER INSERT
+ON mv_base_a FROM mv_ivm_1 FOR EACH ROW
+EXECUTE PROCEDURE dummy_ivm_trigger_func();
+SELECT COUNT(*)
+FROM pg_depend pd INNER JOIN pg_trigger pt ON pd.objid = pt.oid
+WHERE pd.classid = 'pg_trigger'::regclass AND pd.refobjid = 'mv_ivm_1'::regclass;
+ count 
+-------
+    13
+(1 row)
+
+REFRESH MATERIALIZED VIEW mv_ivm_1 WITH NO DATA;
+SELECT COUNT(*)
+FROM pg_depend pd INNER JOIN pg_trigger pt ON pd.objid = pt.oid
+WHERE pd.classid = 'pg_trigger'::regclass AND pd.refobjid = 'mv_ivm_1'::regclass;
+ count 
+-------
+     1
+(1 row)
+
+ROLLBACK;
 -- immediate maintenance
 BEGIN;
 INSERT INTO mv_base_b VALUES(5,105);


### PR DESCRIPTION
This type was used by IMMV, because IMMV must remove IVM triigers
when execute REFRESH with NO DATA option.
Currently, trigger name and dependent objclass is used instead of it.