### PR TITLE
Allow TRUNCATE on base tables

### DIFF
--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -986,9 +986,11 @@ CreateIvmTriggersOnBaseTablesRecurse(Query *qry, Node *node, Oid matviewOid,
 					CreateIvmTrigger(rte->relid, matviewOid, TRIGGER_TYPE_INSERT, TRIGGER_TYPE_BEFORE, ex_lock);
 					CreateIvmTrigger(rte->relid, matviewOid, TRIGGER_TYPE_DELETE, TRIGGER_TYPE_BEFORE, ex_lock);
 					CreateIvmTrigger(rte->relid, matviewOid, TRIGGER_TYPE_UPDATE, TRIGGER_TYPE_BEFORE, ex_lock);
+					CreateIvmTrigger(rte->relid, matviewOid, TRIGGER_TYPE_TRUNCATE, TRIGGER_TYPE_BEFORE, true);
 					CreateIvmTrigger(rte->relid, matviewOid, TRIGGER_TYPE_INSERT, TRIGGER_TYPE_AFTER, ex_lock);
 					CreateIvmTrigger(rte->relid, matviewOid, TRIGGER_TYPE_DELETE, TRIGGER_TYPE_AFTER, ex_lock);
 					CreateIvmTrigger(rte->relid, matviewOid, TRIGGER_TYPE_UPDATE, TRIGGER_TYPE_AFTER, ex_lock);
+					CreateIvmTrigger(rte->relid, matviewOid, TRIGGER_TYPE_TRUNCATE, TRIGGER_TYPE_AFTER, true);
 
 					*relids = bms_add_member(*relids, rte->relid);
 				}
@@ -1060,6 +1062,9 @@ CreateIvmTrigger(Oid relOid, Oid viewOid, int16 type, int16 timing, bool ex_lock
 			break;
 		case TRIGGER_TYPE_UPDATE:
 			ivm_trigger->trigname = (timing == TRIGGER_TYPE_BEFORE ? "IVM_trigger_upd_before" : "IVM_trigger_upd_after");
+			break;
+		case TRIGGER_TYPE_TRUNCATE:
+			ivm_trigger->trigname = (timing == TRIGGER_TYPE_BEFORE ? "IVM_trigger_truncate_before" : "IVM_trigger_truncate_after");
 			break;
 		default:
 			elog(ERROR, "unsupported trigger type");

--- a/src/test/regress/expected/incremental_matview.out
+++ b/src/test/regress/expected/incremental_matview.out
@@ -44,7 +44,7 @@ FROM pg_depend pd INNER JOIN pg_trigger pt ON pd.objid = pt.oid
 WHERE pd.classid = 'pg_trigger'::regclass AND pd.refobjid = 'mv_ivm_1'::regclass;
  count 
 -------
-    13
+    17
 (1 row)
 
 REFRESH MATERIALIZED VIEW mv_ivm_1 WITH NO DATA;
@@ -101,6 +101,23 @@ SELECT * FROM mv_ivm_1 ORDER BY 1,2,3;
  4 | 40 | 104
 (4 rows)
 
+-- TRUNCATE a base table in join views
+BEGIN;
+TRUNCATE mv_base_a;
+SELECT * FROM mv_ivm_1;
+ i | j | k 
+---+---+---
+(0 rows)
+
+ROLLBACK;
+BEGIN;
+TRUNCATE mv_base_b;
+SELECT * FROM mv_ivm_1;
+ i | j | k 
+---+---+---
+(0 rows)
+
+ROLLBACK;
 -- rename of IVM columns
 CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_rename AS SELECT DISTINCT * FROM mv_base_a;
 NOTICE:  created index "mv_ivm_rename_index" on materialized view "mv_ivm_rename"
@@ -256,6 +273,22 @@ SELECT * FROM mv_ivm_agg ORDER BY 1,2,3;
 (5 rows)
 
 ROLLBACK;
+-- TRUNCATE a base table in aggregate views
+BEGIN;
+CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_agg AS SELECT i, SUM(j), COUNT(*) FROM mv_base_a GROUP BY i;
+NOTICE:  created index "mv_ivm_agg_index" on materialized view "mv_ivm_agg"
+TRUNCATE mv_base_a;
+SELECT * FROM mv_ivm_agg;
+ i | sum | count 
+---+-----+-------
+(0 rows)
+
+SELECT i, SUM(j), COUNT(*) FROM mv_base_a GROUP BY i;
+ i | sum | count 
+---+-----+-------
+(0 rows)
+
+ROLLBACK;
 -- support aggregate functions without GROUP clause
 BEGIN;
 CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_group AS SELECT SUM(j), COUNT(j), AVG(j) FROM mv_base_a;
@@ -277,6 +310,26 @@ SELECT * FROM mv_ivm_group ORDER BY 1;
 
 DELETE FROM mv_base_a;
 SELECT * FROM mv_ivm_group ORDER BY 1;
+ sum | count | avg 
+-----+-------+-----
+     |     0 |    
+(1 row)
+
+ROLLBACK;
+-- TRUNCATE a base table in aggregate views without GROUP clause
+BEGIN;
+CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_group AS SELECT SUM(j), COUNT(j), AVG(j) FROM mv_base_a;
+NOTICE:  could not create an index on materialized view "mv_ivm_group" automatically
+DETAIL:  This target list does not have all the primary key columns, or this view does not contain GROUP BY or DISTINCT clause.
+HINT:  Create an index on the materialized view for efficient incremental maintenance.
+TRUNCATE mv_base_a;
+SELECT * FROM mv_ivm_group;
+ sum | count | avg 
+-----+-------+-----
+     |     0 |    
+(1 row)
+
+SELECT SUM(j), COUNT(j), AVG(j) FROM mv_base_a;
  sum | count | avg 
 -----+-------+-----
      |     0 |    
@@ -660,6 +713,24 @@ SELECT *, __ivm_exists_count_0__, __ivm_exists_count_1__ FROM mv_ivm_exists_subq
  3 | 30 |                      2 |                      1
  4 | 40 |                      1 |                      1
 (3 rows)
+
+ROLLBACK;
+-- TRUNCATE a base table in views with EXISTS clause 
+BEGIN;
+CREATE INCREMENTAL MATERIALIZED VIEW mv_ivm_exists_subquery AS SELECT a.i, a.j FROM mv_base_a a WHERE EXISTS(SELECT 1 FROM mv_base_b b WHERE a.i = b.i);
+NOTICE:  could not create an index on materialized view "mv_ivm_exists_subquery" automatically
+DETAIL:  This target list does not have all the primary key columns, or this view does not contain GROUP BY or DISTINCT clause.
+HINT:  Create an index on the materialized view for efficient incremental maintenance.
+TRUNCATE mv_base_b;
+SELECT * FROM mv_ivm_exists_subquery;
+ i | j 
+---+---
+(0 rows)
+
+SELECT a.i, a.j FROM mv_base_a a WHERE EXISTS(SELECT 1 FROM mv_base_b b WHERE a.i = b.i);
+ i | j 
+---+---
+(0 rows)
 
 ROLLBACK;
 -- support simple subquery in FROM clause
@@ -1261,6 +1332,31 @@ SELECT * FROM mv ORDER BY r, si, sj, t;
    |  4 |  2 |  
 (7 rows)
 
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+-- TRUNCATE a base table in views with outer join 
+TRUNCATE base_r;
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+TRUNCATE base_s;
+SELECT is_match();
+ is_match 
+----------
+ OK
+(1 row)
+
+ROLLBACK TO p1;
+TRUNCATE base_t;
 SELECT is_match();
  is_match 
 ----------


### PR DESCRIPTION
If we don't have any outer-joins, the view can be truncated when
a base table is truncated. Otherwise, if we have any outer-joins,
a simple refresh is performed.