### PR TITLE
Fix a bug of automatic index creation

### DIFF
--- a/src/backend/commands/createas.c
+++ b/src/backend/commands/createas.c
@@ -49,6 +49,7 @@
 #include "miscadmin.h"
 #include "optimizer/clauses.h"
 #include "optimizer/optimizer.h"
+#include "optimizer/prep.h"
 #include "nodes/makefuncs.h"
 #include "nodes/nodeFuncs.h"
 #include "parser/parser.h"
@@ -1852,8 +1853,6 @@ get_primary_key_attnos_from_query(Query *query, List **constraintList, bool is_c
 	int i;
 	Bitmapset *keys = NULL;
 	Relids	rels_in_from;
-	PlannerInfo root;
-
 
 	/* This can recurse, so check for excessive recursion */
 	check_stack_depth();
@@ -1929,24 +1928,24 @@ get_primary_key_attnos_from_query(Query *query, List **constraintList, bool is_c
 		if (IsA(tle->expr, Var))
 		{
 			Var *var = (Var*) tle->expr;
-			Bitmapset *attnos = list_nth(key_attnos_list, var->varno - 1);
+			Bitmapset *key_attnos = list_nth(key_attnos_list, var->varno - 1);
 
 			/* check if this attribute is from a base table's primary key */
-			if (bms_is_member(var->varattno - FirstLowInvalidHeapAttributeNumber, attnos))
+			if (bms_is_member(var->varattno - FirstLowInvalidHeapAttributeNumber, key_attnos))
 			{
 				/*
 				 * Remove found key attributes from key_attnos_list, and add this
 				 * to the result list.
 				 */
-				bms_del_member(attnos, var->varattno - FirstLowInvalidHeapAttributeNumber);
+				bms_del_member(key_attnos, var->varattno - FirstLowInvalidHeapAttributeNumber);
 				keys = bms_add_member(keys, i - FirstLowInvalidHeapAttributeNumber);
 			}
 		}
 		i++;
 	}
 
-	/* Collect relations appearing in the FROM clause */
-	rels_in_from = pull_varnos_of_level(&root, (Node *)query->jointree, 0);
+	/* Collect RTE indexes of relations appearing in the FROM clause */
+	rels_in_from = get_relids_in_jointree((Node *) query->jointree, false);
 
 	/*
 	 * Check if all key attributes of relations in FROM are appearing in the target

--- a/src/test/regress/expected/incremental_matview.out
+++ b/src/test/regress/expected/incremental_matview.out
@@ -6114,6 +6114,29 @@ SELECT * FROM ivm_rls2 ORDER BY 1,2,3;
   3 | baz_2 | ivm_user | three_2
 (2 rows)
 
+-- automatic index creation
+BEGIN;
+CREATE TABLE base_a (i int primary key, j int);
+CREATE TABLE base_b (i int primary key, j int);
+--- group by: create an index
+CREATE INCREMENTAL MATERIALIZED VIEW mv_idx1 AS SELECT i, sum(j) FROM base_a GROUP BY i;
+NOTICE:  created index "mv_idx1_index" on materialized view "mv_idx1"
+--- distinct: create an index
+CREATE INCREMENTAL MATERIALIZED VIEW mv_idx2 AS SELECT DISTINCT j FROM base_a;
+NOTICE:  created index "mv_idx2_index" on materialized view "mv_idx2"
+--- with all pkey columns: create an index
+CREATE INCREMENTAL MATERIALIZED VIEW mv_idx3(i_a, i_b) AS SELECT a.i, b.i FROM base_a a, base_b b;
+NOTICE:  created index "mv_idx3_index" on materialized view "mv_idx3"
+--- missing some pkey columns: no index
+CREATE INCREMENTAL MATERIALIZED VIEW mv_idx4 AS SELECT j FROM base_a;
+NOTICE:  could not create an index on materialized view "mv_idx4" automatically
+DETAIL:  This target list does not have all the primary key columns, or this view does not contain GROUP BY or DISTINCT clause.
+HINT:  Create an index on the materialized view for efficient incremental maintenance.
+CREATE INCREMENTAL MATERIALIZED VIEW mv_idx5 AS SELECT a.i, b.j FROM base_a a, base_b b;
+NOTICE:  could not create an index on materialized view "mv_idx5" automatically
+DETAIL:  This target list does not have all the primary key columns, or this view does not contain GROUP BY or DISTINCT clause.
+HINT:  Create an index on the materialized view for efficient incremental maintenance.
+-- cleanup
 DROP TABLE rls_tbl CASCADE;
 NOTICE:  drop cascades to 2 other objects
 DETAIL:  drop cascades to materialized view ivm_rls

--- a/src/test/regress/sql/incremental_matview.sql
+++ b/src/test/regress/sql/incremental_matview.sql
@@ -1834,6 +1834,26 @@ WITH
 SELECT;
 SELECT * FROM ivm_rls2 ORDER BY 1,2,3;
 
+-- automatic index creation
+BEGIN;
+CREATE TABLE base_a (i int primary key, j int);
+CREATE TABLE base_b (i int primary key, j int);
+
+--- group by: create an index
+CREATE INCREMENTAL MATERIALIZED VIEW mv_idx1 AS SELECT i, sum(j) FROM base_a GROUP BY i;
+
+--- distinct: create an index
+CREATE INCREMENTAL MATERIALIZED VIEW mv_idx2 AS SELECT DISTINCT j FROM base_a;
+
+--- with all pkey columns: create an index
+CREATE INCREMENTAL MATERIALIZED VIEW mv_idx3(i_a, i_b) AS SELECT a.i, b.i FROM base_a a, base_b b;
+
+--- missing some pkey columns: no index
+CREATE INCREMENTAL MATERIALIZED VIEW mv_idx4 AS SELECT j FROM base_a;
+CREATE INCREMENTAL MATERIALIZED VIEW mv_idx5 AS SELECT a.i, b.j FROM base_a a, base_b b;
+
+-- cleanup
+
 DROP TABLE rls_tbl CASCADE;
 DROP TABLE num_tbl CASCADE;
 DROP USER ivm_user;


### PR DESCRIPTION
It is intended that a unique index is created only if all primary keys of tables in FROM clause appear in the target list. For this purpose, pull_varnos_of_level was used to extract relations in the FROM clause, but it is incorrect and actually we should use get_relids_in_jointree.

Due to this bug, an index could be created even even where there is a pkey attribute from just one of relations in FROM clause. (#151)